### PR TITLE
Skip dynamic class operands in ForbidUsingStaticPropertiesRule

### DIFF
--- a/src/Rules/ForbidUsingStaticPropertiesRule.php
+++ b/src/Rules/ForbidUsingStaticPropertiesRule.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace AccessingGlobals\Rules;
 
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PhpParser\Node\Identifier;
 
 /**
  * @implements Rule<Node\Expr\StaticPropertyFetch>
@@ -31,7 +32,12 @@ class ForbidUsingStaticPropertiesRule implements Rule
             return [];
         }
 
-        $className = $node->class->toString();
+        $classNode = $node->class;
+        if (!$classNode instanceof Name) {
+            return [];
+        }
+
+        $className = $classNode->toString();
         $propertyName = $node->name instanceof Identifier ? $node->name->toString() : '{expression}';
 
         return [

--- a/tests/Rules/Data/dynamic-static-property.php
+++ b/tests/Rules/Data/dynamic-static-property.php
@@ -1,0 +1,6 @@
+<?php
+
+function readDynamicStaticProperty($object)
+{
+    return $object::$value;
+}

--- a/tests/Rules/ForbidUsingStaticPropertiesRuleTest.php
+++ b/tests/Rules/ForbidUsingStaticPropertiesRuleTest.php
@@ -34,4 +34,12 @@ class ForbidUsingStaticPropertiesRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testDynamicClassOperandIsSkipped(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/dynamic-static-property.php"],
+            [],
+        );
+    }
 }


### PR DESCRIPTION
Closes #1

## Cause

`ForbidUsingStaticPropertiesRule::processNode` called `$node->class->toString()` unconditionally. Dynamic fetches such as `$object::$value` have an expression class operand (`PhpParser\Node\Expr\Variable`), which has no `toString()`, so PHPStan aborted the file with an internal error and an incomplete result.

## Fix

Skip non-`Name` class operands, matching `ForbidUsingClassConstantsRule`. Named-class fetches inside functions and methods still report `property.static`. Root-scope behavior is unchanged.

## Tests

- `testDynamicClassOperandIsSkipped` covers `$object::$value` and expects no diagnostic.
- Existing named-class fixture still reports the two `property.static` errors.