### PR TITLE
Fix duplicate modify.global error in closures declaring their own globals

### DIFF
--- a/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
+++ b/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
@@ -6,6 +6,7 @@ namespace AccessingGlobals\Rules;
 
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
@@ -72,6 +73,11 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
 
             public function enterNode(Node $node)
             {
+                // Nested function-likes are processed by their own invocation of
+                // this rule; `global` declarations do not leak into nested scopes.
+                if ($node instanceof Node\FunctionLike) {
+                    return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+                }
                 if ($node instanceof Node\Stmt\Global_) {
                     foreach ($node->vars as $var) {
                         if ($var instanceof Node\Expr\Variable && is_string($var->name)) {
@@ -119,6 +125,11 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
 
             public function enterNode(Node $node)
             {
+                // Nested function-likes have their own scope: an assignment to a
+                // same-named variable there is not a modification of our global.
+                if ($node instanceof Node\FunctionLike) {
+                    return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+                }
                 if ($node instanceof Node\Expr\Assign) {
                     $assignedTo = $node->var;
 

--- a/tests/Rules/Data/modify-globals-in-closure.php
+++ b/tests/Rules/Data/modify-globals-in-closure.php
@@ -1,0 +1,10 @@
+<?php
+
+function outer(): void
+{
+    $fn = function (): void {
+        global $db;
+        $db = 1;
+    };
+    $fn();
+}

--- a/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
+++ b/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
@@ -30,4 +30,20 @@ class NeverModifyGloballyDeclaredVariablesRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testRuleClosureDeclaresOwnGlobal(): void
+    {
+        // https://github.com/jonbaldie/phpstan-extension-accessing-globals/issues/2
+        // A closure declaring its own `global $db` must produce exactly one
+        // modify.global error, not one per enclosing function-like scope.
+        $this->analyse(
+            [__DIR__ . "/Data/modify-globals-in-closure.php"],
+            [
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    7,
+                ],
+            ],
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`NeverModifyGloballyDeclaredVariablesRule` reported the same assignment **twice** when a closure inside a function declared its own `global $db` and assigned to it.

## Root cause

The rule fires on every `Node\FunctionLike`, and its traversals descended into nested function-likes. For the closure case, both the enclosing function's processing and the closure's own processing collected the `global` declaration and reported the same `Assign` node — an identical `modify.global` error twice. Instrumentation confirmed two `processNode` invocations (`Stmt\Function_` and `Expr\Closure`), each appending one error.

## Fix

Both traversals (`collectGlobalDeclarations` and `findAssignmentsToGlobals`) now stop at nested `Node\FunctionLike` boundaries and let the nested function-like's own rule invocation handle its body. This is also more semantically correct: `global` declarations don't leak into nested scopes in PHP, and an assignment inside a closure without its own `global` statement creates a closure-local variable, not a global modification.

## Testing

- New regression test `testRuleClosureDeclaresOwnGlobal` with `modify-globals-in-closure.php` fixture — failed with the duplicate before the fix, passes after.
- Full suite: 13 tests, 13 assertions, green.
- Manual verification commands from CLAUDE.md reproduce expected counts (36 / 28 / 13).

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)