### PR TITLE
Fix compound assignments bypassing NeverModify rules

### DIFF
--- a/src/Rules/MutationTargetResolver.php
+++ b/src/Rules/MutationTargetResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AccessingGlobals\Rules;
+
+use PhpParser\Node;
+
+final class MutationTargetResolver
+{
+    /**
+     * @return list<Node\Expr>
+     */
+    public static function resolve(Node $node): array
+    {
+        if (
+            !$node instanceof Node\Expr\Assign &&
+            !$node instanceof Node\Expr\AssignOp &&
+            !$node instanceof Node\Expr\AssignRef &&
+            !$node instanceof Node\Expr\PostInc &&
+            !$node instanceof Node\Expr\PreInc &&
+            !$node instanceof Node\Expr\PostDec &&
+            !$node instanceof Node\Expr\PreDec
+        ) {
+            return [];
+        }
+
+        $targets = [$node->var];
+        if ($node instanceof Node\Expr\AssignRef) {
+            $targets[] = $node->expr;
+        }
+
+        $resolvedTargets = [];
+        foreach ($targets as $target) {
+            self::resolveTarget($target, $resolvedTargets);
+        }
+
+        return $resolvedTargets;
+    }
+
+    /**
+     * @param list<Node\Expr> $resolvedTargets
+     */
+    private static function resolveTarget(Node\Expr $target, array &$resolvedTargets): void
+    {
+        if (!$target instanceof Node\Expr\Array_ && !$target instanceof Node\Expr\List_) {
+            $resolvedTargets[] = $target;
+            return;
+        }
+
+        foreach ($target->items as $item) {
+            if ($item === null) {
+                continue;
+            }
+
+            self::resolveTarget($item->value, $resolvedTargets);
+        }
+    }
+}

--- a/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
+++ b/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
@@ -130,18 +130,16 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
                 if ($node instanceof Node\FunctionLike) {
                     return NodeVisitor::DONT_TRAVERSE_CHILDREN;
                 }
-                if ($node instanceof Node\Expr\Assign) {
-                    $assignedTo = $node->var;
-
+                foreach (MutationTargetResolver::resolve($node) as $target) {
                     if (
-                        $assignedTo instanceof Node\Expr\Variable &&
-                        is_string($assignedTo->name) &&
-                        in_array($assignedTo->name, $this->globalVars, true)
+                        $target instanceof Node\Expr\Variable &&
+                        is_string($target->name) &&
+                        in_array($target->name, $this->globalVars, true)
                     ) {
                         $this->errors[] = RuleErrorBuilder::message(
                             sprintf(
                                 'Code is modifying variable $%s that was declared with the "global" keyword. Use dependency injection instead.',
-                                $assignedTo->name,
+                                $target->name,
                             ),
                         )
                             ->line($node->getLine())

--- a/src/Rules/NeverModifyGlobalsRule.php
+++ b/src/Rules/NeverModifyGlobalsRule.php
@@ -13,47 +13,53 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
 
 /**
- * @implements Rule<Node\Expr\Assign>
+ * @implements Rule<Node\Expr>
  */
 class NeverModifyGlobalsRule implements Rule
 {
     public function getNodeType(): string
     {
-        return Node\Expr\Assign::class;
+        return Node\Expr::class;
     }
 
     /**
-     * @param Node\Expr\Assign $node
+     * @param Node\Expr $node
      */
     public function processNode(Node $node, Scope $scope): array
     {
         $errors = [];
-        $assignedTo = $node->var;
 
-        if (!$assignedTo instanceof ArrayDimFetch) {
-            return [];
+        foreach (MutationTargetResolver::resolve($node) as $target) {
+            if (!$target instanceof ArrayDimFetch) {
+                continue;
+            }
+
+            $globalTarget = $target;
+            while ($globalTarget->var instanceof ArrayDimFetch) {
+                $globalTarget = $globalTarget->var;
+            }
+
+            if (
+                !$globalTarget->var instanceof Variable ||
+                $globalTarget->var->name !== "GLOBALS"
+            ) {
+                continue;
+            }
+
+            $key = "unknown";
+            if ($globalTarget->dim instanceof String_) {
+                $key = $globalTarget->dim->value;
+            }
+
+            $errors[] = RuleErrorBuilder::message(
+                sprintf(
+                    'Code is modifying global variable through $GLOBALS[\'%s\']. Use dependency injection instead.',
+                    $key,
+                ),
+            )
+                ->identifier("modify.global")
+                ->build();
         }
-
-        if (
-            !$assignedTo->var instanceof Variable ||
-            $assignedTo->var->name !== "GLOBALS"
-        ) {
-            return [];
-        }
-
-        $key = "unknown";
-        if ($assignedTo->dim instanceof String_) {
-            $key = $assignedTo->dim->value;
-        }
-
-        $errors[] = RuleErrorBuilder::message(
-            sprintf(
-                'Code is modifying global variable through $GLOBALS[\'%s\']. Use dependency injection instead.',
-                $key,
-            ),
-        )
-            ->identifier("modify.global")
-            ->build();
 
         return $errors;
     }

--- a/src/Rules/NeverModifySuperGlobalsInNestedScopeRule.php
+++ b/src/Rules/NeverModifySuperGlobalsInNestedScopeRule.php
@@ -10,18 +10,18 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
- * @implements Rule<Node\Expr\Assign>
+ * @implements Rule<Node\Expr>
  */
 class NeverModifySuperGlobalsInNestedScopeRule extends
     AllowSuperGlobalsInRootScopeRule
 {
     public function getNodeType(): string
     {
-        return Node\Expr\Assign::class;
+        return Node\Expr::class;
     }
 
     /**
-     * @param Node\Expr\Assign $node
+     * @param Node\Expr $node
      */
     public function processNode(Node $node, Scope $scope): array
     {
@@ -29,33 +29,30 @@ class NeverModifySuperGlobalsInNestedScopeRule extends
             return [];
         }
 
-        $var = $node->var;
+        $errors = [];
+        foreach (MutationTargetResolver::resolve($node) as $target) {
+            $var = $target;
 
-        while ($var instanceof Node\Expr\ArrayDimFetch) {
-            $var = $var->var;
-        }
+            while ($var instanceof Node\Expr\ArrayDimFetch) {
+                $var = $var->var;
+            }
 
-        if (!$var instanceof Variable) {
-            return [];
-        }
+            if (!$var instanceof Variable || !is_string($var->name)) {
+                continue;
+            }
 
-        if (!is_string($var->name)) {
-            return [];
-        }
-
-        if (in_array($var->name, $this->superglobals, true)) {
-            return [
-                RuleErrorBuilder::message(
+            if (in_array($var->name, $this->superglobals, true)) {
+                $errors[] = RuleErrorBuilder::message(
                     sprintf(
                         'Code is modifying superglobal variable $%s in a nested scope. Return the new value instead.',
                         $var->name,
                     ),
                 )
                     ->identifier("modify.superglobal.nested")
-                    ->build(),
-            ];
+                    ->build();
+            }
         }
 
-        return [];
+        return $errors;
     }
 }

--- a/src/Rules/NeverModifySuperGlobalsRule.php
+++ b/src/Rules/NeverModifySuperGlobalsRule.php
@@ -11,7 +11,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
- * @implements Rule<Node\Expr\Assign>
+ * @implements Rule<Node\Expr>
  */
 class NeverModifySuperGlobalsRule implements Rule
 {
@@ -32,41 +32,38 @@ class NeverModifySuperGlobalsRule implements Rule
 
     public function getNodeType(): string
     {
-        return Node\Expr\Assign::class;
+        return Node\Expr::class;
     }
 
     /**
-     * @param Node\Expr\Assign $node
+     * @param Node\Expr $node
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        $var = $node->var;
+        $errors = [];
+        foreach (MutationTargetResolver::resolve($node) as $target) {
+            $var = $target;
 
-        while ($var instanceof Node\Expr\ArrayDimFetch) {
-            $var = $var->var;
-        }
+            while ($var instanceof Node\Expr\ArrayDimFetch) {
+                $var = $var->var;
+            }
 
-        if (!$var instanceof Variable) {
-            return [];
-        }
+            if (!$var instanceof Variable || !is_string($var->name)) {
+                continue;
+            }
 
-        if (!is_string($var->name)) {
-            return [];
-        }
-
-        if (in_array($var->name, $this->superglobals, true)) {
-            return [
-                RuleErrorBuilder::message(
+            if (in_array($var->name, $this->superglobals, true)) {
+                $errors[] = RuleErrorBuilder::message(
                     sprintf(
                         'Code is modifying superglobal variable $%s. Return the new value instead.',
                         $var->name,
                     ),
                 )
                     ->identifier("modify.superglobal")
-                    ->build(),
-            ];
+                    ->build();
+            }
         }
 
-        return [];
+        return $errors;
     }
 }

--- a/tests/Rules/Data/issue-3-compound-modifications.php
+++ b/tests/Rules/Data/issue-3-compound-modifications.php
@@ -1,0 +1,43 @@
+<?php
+
+function modifySuperglobals(): void
+{
+    $_SESSION['count'] += 1;
+    $_SESSION['log'] .= 'x';
+    $_GET['page']++;
+    --$_POST['page'];
+    ++$_REQUEST['page'];
+    $_FILES['page']--;
+    $_COOKIE['count'] ??= 1;
+    ['name' => $_SERVER['name']] = ['name' => 'changed'];
+    ['outer' => ['name' => $_SERVER['nested']]] = ['outer' => ['name' => 'changed']];
+    $ref = &$_ENV['name'];
+}
+
+function modifyGlobals(): void
+{
+    $GLOBALS['plus'] += 1;
+    $GLOBALS['concat'] .= 'x';
+    $GLOBALS['postinc']++;
+    --$GLOBALS['predec'];
+    ++$GLOBALS['preinc'];
+    $GLOBALS['postdec']--;
+    $GLOBALS['coalesce'] ??= 1;
+    ['name' => $GLOBALS['destructured']] = ['name' => 'changed'];
+    $ref = &$GLOBALS['reference'];
+}
+
+function modifyGlobalVariable(): void
+{
+    global $db;
+
+    $db += 1;
+    $db .= 'x';
+    $db++;
+    --$db;
+    ++$db;
+    $db--;
+    $db ??= 1;
+    [$db] = [1];
+    $ref = &$db;
+}

--- a/tests/Rules/Data/issue-3-nested-syntax-coverage.php
+++ b/tests/Rules/Data/issue-3-nested-syntax-coverage.php
@@ -1,0 +1,17 @@
+<?php
+
+$_GET['root-plus'] += 1;
+$_POST['root-postinc']++;
+
+function modifyNestedSuperglobalsWithEveryMutationForm(): void
+{
+    $_GET['plus'] += 1;
+    $_POST['concat'] .= 'x';
+    $_REQUEST['postinc']++;
+    --$_SESSION['predec'];
+    ++$_COOKIE['preinc'];
+    $_FILES['postdec']--;
+    $_ENV['coalesce'] ??= 1;
+    ['name' => $_SERVER['destructured']] = ['name' => 'changed'];
+    $ref = &$GLOBALS['reference'];
+}

--- a/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
+++ b/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
@@ -31,6 +31,61 @@ class NeverModifyGloballyDeclaredVariablesRuleTest extends RuleTestCase
         );
     }
 
+    public function testIssue3MutationForms(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-3-compound-modifications.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    34,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    35,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    36,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    37,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    38,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    39,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    40,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    41,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    42,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 9, 'modify.global'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
+
     public function testRuleClosureDeclaresOwnGlobal(): void
     {
         // https://github.com/jonbaldie/phpstan-extension-accessing-globals/issues/2

--- a/tests/Rules/NeverModifyGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifyGlobalsRuleTest.php
@@ -30,4 +30,59 @@ class NeverModifyGlobalsRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testIssue3MutationForms(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-3-compound-modifications.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying global variable through $GLOBALS[\'plus\']. Use dependency injection instead.',
+                    19,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'concat\']. Use dependency injection instead.',
+                    20,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'postinc\']. Use dependency injection instead.',
+                    21,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'predec\']. Use dependency injection instead.',
+                    22,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'preinc\']. Use dependency injection instead.',
+                    23,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'postdec\']. Use dependency injection instead.',
+                    24,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'coalesce\']. Use dependency injection instead.',
+                    25,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'destructured\']. Use dependency injection instead.',
+                    26,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'reference\']. Use dependency injection instead.',
+                    27,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 9, 'modify.global'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }

--- a/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
@@ -62,4 +62,59 @@ class NeverModifySuperGlobalsInNestedScopeRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testIssue3MutationFormsOnlyInNestedScope(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-3-nested-syntax-coverage.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_GET in a nested scope. Return the new value instead.',
+                    8,
+                ],
+                [
+                    'Code is modifying superglobal variable $_POST in a nested scope. Return the new value instead.',
+                    9,
+                ],
+                [
+                    'Code is modifying superglobal variable $_REQUEST in a nested scope. Return the new value instead.',
+                    10,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION in a nested scope. Return the new value instead.',
+                    11,
+                ],
+                [
+                    'Code is modifying superglobal variable $_COOKIE in a nested scope. Return the new value instead.',
+                    12,
+                ],
+                [
+                    'Code is modifying superglobal variable $_FILES in a nested scope. Return the new value instead.',
+                    13,
+                ],
+                [
+                    'Code is modifying superglobal variable $_ENV in a nested scope. Return the new value instead.',
+                    14,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SERVER in a nested scope. Return the new value instead.',
+                    15,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS in a nested scope. Return the new value instead.',
+                    16,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 9, 'modify.superglobal.nested'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }

--- a/tests/Rules/NeverModifySuperGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsRuleTest.php
@@ -62,4 +62,99 @@ class NeverModifySuperGlobalsRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testIssue3MutationForms(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-3-compound-modifications.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    5,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    6,
+                ],
+                [
+                    'Code is modifying superglobal variable $_GET. Return the new value instead.',
+                    7,
+                ],
+                [
+                    'Code is modifying superglobal variable $_POST. Return the new value instead.',
+                    8,
+                ],
+                [
+                    'Code is modifying superglobal variable $_REQUEST. Return the new value instead.',
+                    9,
+                ],
+                [
+                    'Code is modifying superglobal variable $_FILES. Return the new value instead.',
+                    10,
+                ],
+                [
+                    'Code is modifying superglobal variable $_COOKIE. Return the new value instead.',
+                    11,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SERVER. Return the new value instead.',
+                    12,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SERVER. Return the new value instead.',
+                    13,
+                ],
+                [
+                    'Code is modifying superglobal variable $_ENV. Return the new value instead.',
+                    14,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    19,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    20,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    21,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    22,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    23,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    24,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    25,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    26,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    27,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 19, 'modify.superglobal'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- cover compound assignments, pre/post increments and decrements, reference binding, and destructuring targets
- share mutation-target resolution across all four NeverModify rules
- preserve existing diagnostics and root/nested scope behavior

## Verification

- `vendor/bin/phpunit` (17 tests, 17 assertions)
- documented manual checks: 13/13 expected exit codes and error counts
- issue reproducer: strict rules emit `modify.superglobal` and `modify.global` diagnostics for every supported write

Fixes #3