### PR TITLE
Fix false positive modify.global when nested scopes shadow globals

### DIFF
--- a/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
+++ b/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
@@ -107,8 +107,8 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
     ): void {
         $traverser = new NodeTraverser();
         $visitor = new class($globalVars, $errors) extends NodeVisitorAbstract {
-            /** @var array<string> */
-            private array $globalVars;
+            /** @var list<array<string>> */
+            private array $bindingStack;
 
             /** @var array<\PHPStan\Rules\RuleError> */
             private array $errors;
@@ -119,22 +119,25 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
              */
             public function __construct(array $globalVars, array &$errors)
             {
-                $this->globalVars = $globalVars;
+                $this->bindingStack = [$globalVars];
                 $this->errors = &$errors;
             }
 
             public function enterNode(Node $node)
             {
-                // Nested function-likes have their own scope: an assignment to a
-                // same-named variable there is not a modification of our global.
                 if ($node instanceof Node\FunctionLike) {
-                    return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+                    $this->bindingStack[] = $this->bindingsForNested($node);
+                    if ($this->currentGlobals() === []) {
+                        return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+                    }
+
+                    return null;
                 }
                 foreach (MutationTargetResolver::resolve($node) as $target) {
                     if (
                         $target instanceof Node\Expr\Variable &&
                         is_string($target->name) &&
-                        in_array($target->name, $this->globalVars, true)
+                        in_array($target->name, $this->currentGlobals(), true)
                     ) {
                         $this->errors[] = RuleErrorBuilder::message(
                             sprintf(
@@ -148,6 +151,53 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
                     }
                 }
                 return null;
+            }
+
+            public function leaveNode(Node $node)
+            {
+                if ($node instanceof Node\FunctionLike) {
+                    array_pop($this->bindingStack);
+                }
+
+                return null;
+            }
+
+            /**
+             * @return array<string>
+             */
+            private function currentGlobals(): array
+            {
+                return $this->bindingStack[array_key_last($this->bindingStack)] ?? [];
+            }
+
+            /**
+             * @return array<string>
+             */
+            private function bindingsForNested(Node\FunctionLike $node): array
+            {
+                $inherited = [];
+                if ($node instanceof Node\Expr\Closure) {
+                    foreach ($node->uses as $use) {
+                        $name = $use->var->name;
+                        if (
+                            $use->byRef
+                            && is_string($name)
+                            && in_array($name, $this->currentGlobals(), true)
+                        ) {
+                            $inherited[] = $name;
+                        }
+                    }
+                }
+                foreach ($node->getParams() as $param) {
+                    if (
+                        $param->var instanceof Node\Expr\Variable
+                        && is_string($param->var->name)
+                    ) {
+                        $inherited = array_values(array_diff($inherited, [$param->var->name]));
+                    }
+                }
+
+                return $inherited;
             }
         };
 

--- a/tests/Rules/Data/issue-4-nested-shadowing.php
+++ b/tests/Rules/Data/issue-4-nested-shadowing.php
@@ -1,0 +1,20 @@
+<?php
+
+function issue4ShadowingAndCapture(): void
+{
+    global $db;
+    $fn = function (int $db): int {
+        $db = 5;
+        return $db;
+    };
+    $fn(1);
+    $g = function () use ($db): void {
+        $db = 'local only';
+    };
+    $g();
+    $h = function () use (&$db): void {
+        $db = 'mutates global';
+    };
+    $h();
+    $db = 'outer write';
+}

--- a/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
+++ b/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
@@ -86,6 +86,33 @@ class NeverModifyGloballyDeclaredVariablesRuleTest extends RuleTestCase
         );
     }
 
+    public function testIssue4NestedShadowingAndByRefCapture(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-4-nested-shadowing.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    16,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    19,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            ['modify.global', 'modify.global'],
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
+
     public function testRuleClosureDeclaresOwnGlobal(): void
     {
         // https://github.com/jonbaldie/phpstan-extension-accessing-globals/issues/2


### PR DESCRIPTION
## Summary

`NeverModifyGloballyDeclaredVariablesRule` treated every nested function-like as a hard scope boundary. That correctly avoided false `modify.global` reports for parameter shadowing and by-value `use` copies, but it also missed genuine mutations through `use (&$db)`.

## Root cause

Issue #8 stopped both traversals at nested `FunctionLike` nodes. `processNode` on the inner closure does not treat a by-ref `use` as a global declaration, so a write to the captured alias was never diagnosed.

If the assignment is skipped solely because it sits in a nested function-like, then by-ref captures of a globally declared variable disappear. Parameters and by-value captures must still be ignored: they do not mutate the global.

## Fix

`findAssignmentsToGlobals` now tracks a binding stack. Nested closures inherit a name only when they capture it by reference. Parameters and by-value uses start a new local binding and are not reported. Nested functions that declare their own `global $db` are still handled by their own `processNode` invocation (exactly one diagnostic).

## Testing

- Regression test `testIssue4NestedShadowingAndByRefCapture` with `issue-4-nested-shadowing.php`: no diagnostics for parameter / by-value writes; `modify.global` for by-ref capture and the outer write.
- Existing `testRuleClosureDeclaresOwnGlobal` still expects exactly one error.
- `vendor/bin/phpunit`: 18 tests, 23 assertions, green.
- Manual verification counts unchanged: 36 / 28 / 13.

Fixes #4