### PR TITLE
Treat root-scope closures as nested scopes

### DIFF
--- a/src/Rules/AllowSuperGlobalsInRootScopeRule.php
+++ b/src/Rules/AllowSuperGlobalsInRootScopeRule.php
@@ -30,6 +30,10 @@ abstract class AllowSuperGlobalsInRootScopeRule implements Rule
 
     protected function isInRootScope(Scope $scope): bool
     {
-        return $scope->getFunction() === null && !$scope->isInClass();
+        // Closures and arrow functions defined at file scope have no enclosing
+        // function, but their bodies are still nested scopes, not root code.
+        return $scope->getFunction() === null
+            && !$scope->isInClass()
+            && !$scope->isInAnonymousFunction();
     }
 }

--- a/src/Rules/ForbidImpureGlobalFunctionsRule.php
+++ b/src/Rules/ForbidImpureGlobalFunctionsRule.php
@@ -84,7 +84,9 @@ class ForbidImpureGlobalFunctionsRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         // We only care about code inside a function or method.
-        if ($scope->getFunction() === null) {
+        // Closures and arrow functions defined at file scope have no enclosing
+        // function, but their bodies are nested scopes, not root code.
+        if ($scope->getFunction() === null && !$scope->isInAnonymousFunction()) {
             return [];
         }
 

--- a/src/Rules/ForbidUsingClassConstantsRule.php
+++ b/src/Rules/ForbidUsingClassConstantsRule.php
@@ -28,7 +28,9 @@ class ForbidUsingClassConstantsRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         // We only care about code inside a function or method.
-        if ($scope->getFunction() === null) {
+        // Closures and arrow functions defined at file scope have no enclosing
+        // function, but their bodies are nested scopes, not root code.
+        if ($scope->getFunction() === null && !$scope->isInAnonymousFunction()) {
             return [];
         }
 

--- a/src/Rules/ForbidUsingGlobalConstantsRule.php
+++ b/src/Rules/ForbidUsingGlobalConstantsRule.php
@@ -24,8 +24,10 @@ class ForbidUsingGlobalConstantsRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        // We only care about code inside a function or method
-        if ($scope->getFunction() === null) {
+        // We only care about code inside a function or method.
+        // Closures and arrow functions defined at file scope have no enclosing
+        // function, but their bodies are nested scopes, not root code.
+        if ($scope->getFunction() === null && !$scope->isInAnonymousFunction()) {
             return [];
         }
 

--- a/src/Rules/ForbidUsingStaticPropertiesRule.php
+++ b/src/Rules/ForbidUsingStaticPropertiesRule.php
@@ -28,7 +28,12 @@ class ForbidUsingStaticPropertiesRule implements Rule
     {
         // We only care about code inside a function or method.
         // Access in the global scope (e.g. for configuration) is not our concern.
-        if ($scope->getFunction() === null && !$scope->isInClass()) {
+        // Closures and arrow functions defined at file scope have no enclosing
+        // function, but their bodies are nested scopes, not root code.
+        if ($scope->getFunction() === null
+            && !$scope->isInClass()
+            && !$scope->isInAnonymousFunction()
+        ) {
             return [];
         }
 

--- a/tests/Rules/Data/issue-5-root-scope-closures-access.php
+++ b/tests/Rules/Data/issue-5-root-scope-closures-access.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AccessingGlobals\Tests\Rules\Data;
+
+// Ordinary root statements are allowed by the nested-scope rules.
+$_GET['q'];
+
+// A root-level closure reading a superglobal is a nested scope.
+$fn = function (): void {
+    echo $_POST['q'];
+};
+
+// A root-level arrow function reading a superglobal is a nested scope.
+$arrow = fn (): int => count($_SESSION);

--- a/tests/Rules/Data/issue-5-root-scope-closures-modify.php
+++ b/tests/Rules/Data/issue-5-root-scope-closures-modify.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AccessingGlobals\Tests\Rules\Data;
+
+// Ordinary root statements are allowed by the nested-scope rules.
+$_SESSION['u'] = 'x';
+
+// A root-level closure modifying a superglobal is a nested scope.
+$mutate = function (): void {
+    $_COOKIE['user'] = 'jane';
+};
+
+// A root-level arrow function modifying a superglobal is a nested scope.
+$mutateArrow = fn (): void => $_SERVER['c'] = '1';

--- a/tests/Rules/Data/issue-5-root-scope-closures-opinionated.php
+++ b/tests/Rules/Data/issue-5-root-scope-closures-opinionated.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AccessingGlobals\Tests\Rules\Data;
+
+define('ISSUE_FIVE_CONST', 1);
+
+class IssueFiveConfig
+{
+    public const BAR = 1;
+
+    public static $prop = 2;
+}
+
+// Root-level code is not these rules' concern.
+$x = ISSUE_FIVE_CONST;
+$y = IssueFiveConfig::BAR;
+$z = IssueFiveConfig::$prop;
+time();
+
+// A root-level closure is a nested scope for the opinionated rules.
+$fn = function (): int {
+    return time() + ISSUE_FIVE_CONST + IssueFiveConfig::BAR + IssueFiveConfig::$prop;
+};
+
+// A root-level arrow function is a nested scope too.
+$arrow = fn (): int => rand();

--- a/tests/Rules/ForbidImpureGlobalFunctionsRuleTest.php
+++ b/tests/Rules/ForbidImpureGlobalFunctionsRuleTest.php
@@ -42,4 +42,21 @@ class ForbidImpureGlobalFunctionsRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testIssue5RootScopeClosures(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-5-root-scope-closures-opinionated.php"],
+            [
+                [
+                    'Code is calling the impure function "time()". This creates a hidden dependency on external state; pass the result as an argument instead.',
+                    22,
+                ],
+                [
+                    'Code is calling the impure function "rand()". This creates a hidden dependency on external state; pass the result as an argument instead.',
+                    26,
+                ],
+            ],
+        );
+    }
 }

--- a/tests/Rules/ForbidUsingClassConstantsRuleTest.php
+++ b/tests/Rules/ForbidUsingClassConstantsRuleTest.php
@@ -34,4 +34,17 @@ class ForbidUsingClassConstantsRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testIssue5RootScopeClosures(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-5-root-scope-closures-opinionated.php"],
+            [
+                [
+                    "Code is accessing constant AccessingGlobals\Tests\Rules\Data\IssueFiveConfig::BAR. This creates a hidden dependency; pass the value as an argument instead.",
+                    22,
+                ],
+            ],
+        );
+    }
 }

--- a/tests/Rules/ForbidUsingGlobalConstantsRuleTest.php
+++ b/tests/Rules/ForbidUsingGlobalConstantsRuleTest.php
@@ -38,4 +38,17 @@ class ForbidUsingGlobalConstantsRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testIssue5RootScopeClosures(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-5-root-scope-closures-opinionated.php"],
+            [
+                [
+                    'Code is accessing global constant "ISSUE_FIVE_CONST". Pass it as an argument instead to make the dependency explicit.',
+                    22,
+                ],
+            ],
+        );
+    }
 }

--- a/tests/Rules/ForbidUsingStaticPropertiesRuleTest.php
+++ b/tests/Rules/ForbidUsingStaticPropertiesRuleTest.php
@@ -42,4 +42,17 @@ class ForbidUsingStaticPropertiesRuleTest extends RuleTestCase
             [],
         );
     }
+
+    public function testIssue5RootScopeClosures(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-5-root-scope-closures-opinionated.php"],
+            [
+                [
+                    'Code is accessing static property AccessingGlobals\Tests\Rules\Data\IssueFiveConfig::$prop. Static properties are global state; pass the value as an argument instead.',
+                    22,
+                ],
+            ],
+        );
+    }
 }

--- a/tests/Rules/NeverAccessSuperGlobalsInNestedScopeRuleTest.php
+++ b/tests/Rules/NeverAccessSuperGlobalsInNestedScopeRuleTest.php
@@ -62,4 +62,21 @@ class NeverAccessSuperGlobalsInNestedScopeRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testIssue5RootScopeClosures(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-5-root-scope-closures-access.php"],
+            [
+                [
+                    'Code is accessing superglobal variable $_POST in a nested scope. Pass the value as an argument instead.',
+                    10,
+                ],
+                [
+                    'Code is accessing superglobal variable $_SESSION in a nested scope. Pass the value as an argument instead.',
+                    14,
+                ],
+            ],
+        );
+    }
 }

--- a/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
@@ -117,4 +117,21 @@ class NeverModifySuperGlobalsInNestedScopeRuleTest extends RuleTestCase
             ),
         );
     }
+
+    public function testIssue5RootScopeClosures(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-5-root-scope-closures-modify.php"],
+            [
+                [
+                    'Code is modifying superglobal variable $_COOKIE in a nested scope. Return the new value instead.',
+                    10,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SERVER in a nested scope. Return the new value instead.',
+                    14,
+                ],
+            ],
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closures and arrow functions defined at file scope were exempt from the nested-scope rules and all four opinionated rules, because `Scope::getFunction()` returns `null` for them (it is only non-null for enclosing *named* functions/methods). The identical closure was treated as nested when defined inside a method and as root when defined at file scope.

**Fix:** add `!$scope->isInAnonymousFunction()` to the root-scope guards of:

- `AllowSuperGlobalsInRootScopeRule` (shared by both nested-scope superglobal rules)
- `ForbidImpureGlobalFunctionsRule`
- `ForbidUsingGlobalConstantsRule`
- `ForbidUsingClassConstantsRule`
- `ForbidUsingStaticPropertiesRule`

For the three opinionated rules whose guard was `getFunction() === null` alone, the `isInClass()` clause is deliberately *not* added, so class-body constant/property accesses keep their current behavior.

## Diagnosis

Instrumented probes (removed before this PR) confirmed the hypothesis: inside a root-level closure body the scope reported `getFunction=NULL, isInClass=false, isInAnonymousFunction=true`, versus `getFunction='m', isInClass=true, isInAnonymousFunction=true` for the identical closure inside a method. `isInAnonymousFunction()` is therefore the discriminating signal.

## Verification

- New regression tests (`testIssue5RootScopeClosures` in six rule test classes) failed before the fix and pass after: closures + arrow functions, superglobal reads and writes, and `function.impure` / `constant.global` / `constant.class` / `property.static`.
- Full suite: 24 tests, 29 assertions, green.
- All documented manual verification error counts unchanged (3/5/9/19 basic, 9/19 strict, 3/2/2/4 opinionated, 36/28/13 combined).
- Ordinary root statements remain allowed by the weaker rules (negative controls in the fixtures).

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)