### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## 0.4.0
+
+- Treat root-scope closures as nested scopes (#5, #11)
+- Fix `modify.global` nested shadowing and by-ref captures (#10)
+- Fix compound global modifications (#9)
+- Fix duplicate `modify.global` error in closures declaring their own globals (#8)
+- Skip dynamic class operands in `ForbidUsingStaticPropertiesRule` (#7)
+
+## 0.3.1
+
+- CI workflow fixes
+
+## 0.3.0
+
+- CI workflow
+
+## 0.2.6
+
+- Clearer error wording
+
+## 0.2.4
+
+- Purposeful-failure test fixtures fixed
+
+## 0.2.2
+
+- Purposeful-failure test fixtures added
+
+## 0.2.1
+
+- Added PHP 8.4 to CI
+
+## 0.2.0
+
+- CI pinned to PHP 8.3
+
+## 0.1.0
+
+- New default ruleset


### PR DESCRIPTION
## Release v0.4.0

Minor version bump covering the rule fixes merged since v0.3.1:

- Treat root-scope closures as nested scopes (#5, #11)
- Fix `modify.global` nested shadowing and by-ref captures (#10)
- Fix compound global modifications (#9)
- Fix duplicate `modify.global` error in closures declaring their own globals (#8)
- Skip dynamic class operands in `ForbidUsingStaticPropertiesRule` (#7)

Adds a `CHANGELOG.md` backfilling release notes for all prior tags.

Local verification: PHPUnit 24/24 passing; manual rule sweep reports the documented 36 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)