### PR TITLE
Fix foreach value targets in NeverModify rules

### DIFF
--- a/src/Rules/MutationTargetResolver.php
+++ b/src/Rules/MutationTargetResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AccessingGlobals\Rules;
 
 use PhpParser\Node;
+use PHPStan\Node\Expr\NativeTypeExpr;
 
 final class MutationTargetResolver
 {
@@ -13,7 +14,19 @@ final class MutationTargetResolver
      */
     public static function resolve(Node $node): array
     {
+        // PHPStan emits a synthetic assignment for destructured foreach values.
+        // The owning Foreach_ node is the real mutation event; processing both
+        // would report every destructured target twice.
         if (
+            $node instanceof Node\Expr\Assign
+            && get_class($node->expr) === NativeTypeExpr::class
+        ) {
+            return [];
+        }
+
+        if ($node instanceof Node\Stmt\Foreach_) {
+            $targets = [$node->valueVar];
+        } elseif (
             !$node instanceof Node\Expr\Assign &&
             !$node instanceof Node\Expr\AssignOp &&
             !$node instanceof Node\Expr\AssignRef &&
@@ -23,11 +36,11 @@ final class MutationTargetResolver
             !$node instanceof Node\Expr\PreDec
         ) {
             return [];
-        }
-
-        $targets = [$node->var];
-        if ($node instanceof Node\Expr\AssignRef) {
-            $targets[] = $node->expr;
+        } else {
+            $targets = [$node->var];
+            if ($node instanceof Node\Expr\AssignRef) {
+                $targets[] = $node->expr;
+            }
         }
 
         $resolvedTargets = [];

--- a/src/Rules/NeverModifyGlobalsRule.php
+++ b/src/Rules/NeverModifyGlobalsRule.php
@@ -13,17 +13,17 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
 
 /**
- * @implements Rule<Node\Expr>
+ * @implements Rule<Node>
  */
 class NeverModifyGlobalsRule implements Rule
 {
     public function getNodeType(): string
     {
-        return Node\Expr::class;
+        return Node::class;
     }
 
     /**
-     * @param Node\Expr $node
+     * @param Node $node
      */
     public function processNode(Node $node, Scope $scope): array
     {

--- a/src/Rules/NeverModifySuperGlobalsInNestedScopeRule.php
+++ b/src/Rules/NeverModifySuperGlobalsInNestedScopeRule.php
@@ -9,19 +9,16 @@ use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 
-/**
- * @implements Rule<Node\Expr>
- */
 class NeverModifySuperGlobalsInNestedScopeRule extends
     AllowSuperGlobalsInRootScopeRule
 {
     public function getNodeType(): string
     {
-        return Node\Expr::class;
+        return Node::class;
     }
 
     /**
-     * @param Node\Expr $node
+     * @param Node $node
      */
     public function processNode(Node $node, Scope $scope): array
     {

--- a/src/Rules/NeverModifySuperGlobalsRule.php
+++ b/src/Rules/NeverModifySuperGlobalsRule.php
@@ -11,7 +11,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
- * @implements Rule<Node\Expr>
+ * @implements Rule<Node>
  */
 class NeverModifySuperGlobalsRule implements Rule
 {
@@ -32,11 +32,11 @@ class NeverModifySuperGlobalsRule implements Rule
 
     public function getNodeType(): string
     {
-        return Node\Expr::class;
+        return Node::class;
     }
 
     /**
-     * @param Node\Expr $node
+     * @param Node $node
      */
     public function processNode(Node $node, Scope $scope): array
     {

--- a/tests/Rules/Data/issue-13-foreach-global-binding.php
+++ b/tests/Rules/Data/issue-13-foreach-global-binding.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+function modifyGlobal(): void
+{
+    global $db;
+
+    foreach ([1] as &$db) {
+    }
+}

--- a/tests/Rules/Data/issue-13-foreach-global-targets.php
+++ b/tests/Rules/Data/issue-13-foreach-global-targets.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+foreach ([1] as $GLOBALS['root']) {
+}
+
+foreach ([1] as $GLOBALS['outer']['inner']) {
+}
+
+foreach ($GLOBALS['iterable'] as $GLOBALS['key'] => $GLOBALS['value']) {
+}
+
+foreach ([1] as [$_GET['ignored'], $GLOBALS['destructured']]) {
+}

--- a/tests/Rules/Data/issue-13-foreach-superglobals.php
+++ b/tests/Rules/Data/issue-13-foreach-superglobals.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+foreach ([1] as $_GET['root']) {
+}
+
+foreach ([1] as $_POST['outer']['inner']) {
+}
+
+foreach ($GLOBALS['iterable'] as $GLOBALS['key'] => $_REQUEST['value']) {
+}
+
+foreach ([1] as [$_SESSION['first'], $_COOKIE['second']['nested']]) {
+}
+
+function nestedScope(): void
+{
+    foreach ([1] as [$_FILES['nested'], $_ENV['deep']['nested']]) {
+    }
+}

--- a/tests/Rules/Data/issue-13-foreach-value-target.php
+++ b/tests/Rules/Data/issue-13-foreach-value-target.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+foreach ([1] as $_GET['key']) {
+}

--- a/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
+++ b/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
@@ -128,4 +128,27 @@ class NeverModifyGloballyDeclaredVariablesRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testIssue13ForeachByReferenceValueTarget(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-13-foreach-global-binding.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    9,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            ['modify.global'],
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }

--- a/tests/Rules/NeverModifyGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifyGlobalsRuleTest.php
@@ -85,4 +85,39 @@ class NeverModifyGlobalsRuleTest extends RuleTestCase
             ),
         );
     }
+
+    public function testIssue13ForeachValueTargets(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-13-foreach-global-targets.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying global variable through $GLOBALS[\'root\']. Use dependency injection instead.',
+                    5,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'outer\']. Use dependency injection instead.',
+                    8,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'value\']. Use dependency injection instead.',
+                    11,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'destructured\']. Use dependency injection instead.',
+                    14,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 4, 'modify.global'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }

--- a/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
@@ -134,4 +134,31 @@ class NeverModifySuperGlobalsInNestedScopeRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testIssue13ForeachValueTargetsOnlyInNestedScope(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-13-foreach-superglobals.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_ENV in a nested scope. Return the new value instead.',
+                    19,
+                ],
+                [
+                    'Code is modifying superglobal variable $_FILES in a nested scope. Return the new value instead.',
+                    19,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 2, 'modify.superglobal.nested'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }

--- a/tests/Rules/NeverModifySuperGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsRuleTest.php
@@ -157,4 +157,64 @@ class NeverModifySuperGlobalsRuleTest extends RuleTestCase
             ),
         );
     }
+
+    public function testIssue13ForeachValueTarget(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-13-foreach-value-target.php"],
+            [
+                [
+                    'Code is modifying superglobal variable $_GET. Return the new value instead.',
+                    5,
+                ],
+            ],
+        );
+    }
+
+    public function testIssue13ForeachValueTargets(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-13-foreach-superglobals.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_GET. Return the new value instead.',
+                    5,
+                ],
+                [
+                    'Code is modifying superglobal variable $_POST. Return the new value instead.',
+                    8,
+                ],
+                [
+                    'Code is modifying superglobal variable $_REQUEST. Return the new value instead.',
+                    11,
+                ],
+                [
+                    'Code is modifying superglobal variable $_COOKIE. Return the new value instead.',
+                    14,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    14,
+                ],
+                [
+                    'Code is modifying superglobal variable $_ENV. Return the new value instead.',
+                    19,
+                ],
+                [
+                    'Code is modifying superglobal variable $_FILES. Return the new value instead.',
+                    19,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 7, 'modify.superglobal'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }


### PR DESCRIPTION
Fixes #13

## Summary

- Treat the value side of `Foreach_` as a mutation target, including array dimensions and destructuring.
- Keep foreach keys and iterables out of mutation analysis.
- Register the three expression-based NeverModify rules for all PHPStan nodes so they receive `Foreach_` statements.
- Ignore PHPStan synthetic destructuring assignments to avoid duplicate diagnostics.
- Add regression coverage for superglobals, `$GLOBALS`, nested scopes, and by-reference global bindings.

## Diagnosis

The mutation resolver only recognized expression nodes, while PHPStan reports the owning `Foreach_` statement for foreach value writes. The resolver therefore never saw direct foreach value targets. Dispatching the rules for `Node` and resolving only `Foreach_::valueVar` closes that gap; PHPStan synthetic destructuring assignments are filtered because the real mutation is already represented by the owning foreach statement.

## Verification

- `vendor/bin/phpunit` — 29 tests, 38 assertions passed.
- Basic aggregate PHPStan verification — 36 errors, exit 1.
- Strict aggregate PHPStan verification — 28 errors, exit 1.
- Opinionated aggregate PHPStan verification — 13 errors, exit 1.
- Targeted PHPStan analysis of changed source — no errors.