### PR TITLE
Detect unset() as a global mutation

### DIFF
--- a/src/Rules/MutationTargetResolver.php
+++ b/src/Rules/MutationTargetResolver.php
@@ -24,7 +24,9 @@ final class MutationTargetResolver
             return [];
         }
 
-        if ($node instanceof Node\Stmt\Foreach_) {
+        if ($node instanceof Node\Stmt\Unset_) {
+            $targets = $node->vars;
+        } elseif ($node instanceof Node\Stmt\Foreach_) {
             $targets = [$node->valueVar];
         } elseif (
             !$node instanceof Node\Expr\Assign &&

--- a/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
+++ b/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
@@ -94,7 +94,7 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
     }
 
     /**
-     * Traverse the function to find assignments to globally declared variables.
+     * Traverse the function to find mutations of globally declared variables.
      *
      * @param Node\FunctionLike $function
      * @param array<string> $globalVars
@@ -134,6 +134,14 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
                     return null;
                 }
                 foreach (MutationTargetResolver::resolve($node) as $target) {
+                    // `unset($db)` removes the local binding created by
+                    // `global $db`; it does not remove the global variable.
+                    if (
+                        $node instanceof Node\Stmt\Unset_
+                        && $target instanceof Node\Expr\Variable
+                    ) {
+                        continue;
+                    }
                     if (
                         $target instanceof Node\Expr\Variable &&
                         is_string($target->name) &&

--- a/tests/Rules/Data/issue-14-unset-coverage.php
+++ b/tests/Rules/Data/issue-14-unset-coverage.php
@@ -1,0 +1,10 @@
+<?php
+
+// Root-scope mutations are checked by the strict rule.
+unset($_GET['root']);
+unset($GLOBALS['root']);
+
+function unsetMultipleTargets(): void
+{
+    unset($_POST['nested'], $_SESSION['nested']['deep'], $GLOBALS['outer']['inner']);
+}

--- a/tests/Rules/Data/issue-14-unset-global-binding.php
+++ b/tests/Rules/Data/issue-14-unset-global-binding.php
@@ -1,0 +1,8 @@
+<?php
+
+function unsetGlobalBinding(): void
+{
+    global $db;
+
+    unset($db);
+}

--- a/tests/Rules/Data/issue-14-unset.php
+++ b/tests/Rules/Data/issue-14-unset.php
@@ -1,0 +1,6 @@
+<?php
+
+function unsetSuperglobalKey(): void
+{
+    unset($_GET['k']);
+}

--- a/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
+++ b/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
@@ -151,4 +151,12 @@ class NeverModifyGloballyDeclaredVariablesRuleTest extends RuleTestCase
             ),
         );
     }
+
+    public function testIssue14UnsetGlobalBindingIsNotMutation(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-14-unset-global-binding.php"],
+            [],
+        );
+    }
 }

--- a/tests/Rules/NeverModifyGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifyGlobalsRuleTest.php
@@ -120,4 +120,31 @@ class NeverModifyGlobalsRuleTest extends RuleTestCase
             ),
         );
     }
+
+    public function testIssue14UnsetGlobalTargets(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-14-unset-coverage.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying global variable through $GLOBALS[\'root\']. Use dependency injection instead.',
+                    5,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'outer\']. Use dependency injection instead.',
+                    9,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 2, 'modify.global'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }

--- a/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
@@ -161,4 +161,48 @@ class NeverModifySuperGlobalsInNestedScopeRuleTest extends RuleTestCase
             ),
         );
     }
+
+    public function testIssue14UnsetSuperglobalKey(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-14-unset.php"],
+            [
+                [
+                    'Code is modifying superglobal variable $_GET in a nested scope. Return the new value instead.',
+                    5,
+                ],
+            ],
+        );
+    }
+
+    public function testIssue14UnsetTargetsInNestedScope(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-14-unset-coverage.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_POST in a nested scope. Return the new value instead.',
+                    9,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION in a nested scope. Return the new value instead.',
+                    9,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS in a nested scope. Return the new value instead.',
+                    9,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 3, 'modify.superglobal.nested'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }

--- a/tests/Rules/NeverModifySuperGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsRuleTest.php
@@ -217,4 +217,43 @@ class NeverModifySuperGlobalsRuleTest extends RuleTestCase
             ),
         );
     }
+
+    public function testIssue14UnsetTargets(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-14-unset-coverage.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_GET. Return the new value instead.',
+                    4,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    5,
+                ],
+                [
+                    'Code is modifying superglobal variable $_POST. Return the new value instead.',
+                    9,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    9,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    9,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 5, 'modify.superglobal'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }


### PR DESCRIPTION
Fixes #14

## Summary

- Resolve each unset() lvalue as a mutation target so superglobal and $GLOBALS modification rules report it.
- Preserve the local-binding semantics of unset($db) after global $db.
- Add root-scope, nested-scope, multiple-target, nested-dimension, $GLOBALS, and negative binding regression coverage.

## Tests

- vendor/bin/phpunit — 34 tests, 46 assertions
- Documented PHPStan verification suites — 36 basic, 28 strict, and 13 opinionated errors
