### PR TITLE
Fix dimension writes to globally-declared variables

### DIFF
--- a/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
+++ b/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
@@ -142,15 +142,21 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
                     ) {
                         continue;
                     }
+
+                    $globalTarget = $target;
+                    while ($globalTarget instanceof Node\Expr\ArrayDimFetch) {
+                        $globalTarget = $globalTarget->var;
+                    }
+
                     if (
-                        $target instanceof Node\Expr\Variable &&
-                        is_string($target->name) &&
-                        in_array($target->name, $this->currentGlobals(), true)
+                        $globalTarget instanceof Node\Expr\Variable &&
+                        is_string($globalTarget->name) &&
+                        in_array($globalTarget->name, $this->currentGlobals(), true)
                     ) {
                         $this->errors[] = RuleErrorBuilder::message(
                             sprintf(
                                 'Code is modifying variable $%s that was declared with the "global" keyword. Use dependency injection instead.',
-                                $target->name,
+                                $globalTarget->name,
                             ),
                         )
                             ->line($node->getLine())

--- a/tests/Rules/Data/issue-15-dimension-writes.php
+++ b/tests/Rules/Data/issue-15-dimension-writes.php
@@ -1,0 +1,17 @@
+<?php
+
+function modifyGlobalDimensions()
+{
+    global $db;
+
+    $db['key'] = 1;
+    $db['outer']['inner'] = 2;
+    $db['compound'] += 1;
+    ++$db['preIncrement'];
+    $db['postIncrement']++;
+    --$db['preDecrement'];
+    $db['postDecrement']--;
+    $ref = &$db['reference'];
+    ['key' => $db['destructured']] = ['key' => 1];
+    $local['key'] = 1;
+}

--- a/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
+++ b/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
@@ -86,6 +86,61 @@ class NeverModifyGloballyDeclaredVariablesRuleTest extends RuleTestCase
         );
     }
 
+    public function testIssue15DimensionMutationForms(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-15-dimension-writes.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    7,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    8,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    9,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    10,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    11,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    12,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    13,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    14,
+                ],
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    15,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 9, 'modify.global'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
+
     public function testIssue4NestedShadowingAndByRefCapture(): void
     {
         $fixture = __DIR__ . "/Data/issue-4-nested-shadowing.php";


### PR DESCRIPTION
## Summary

- report mutations whose target is an array dimension of a globally-declared variable
- cover nested dimensions, compound/increment/decrement/reference/destructuring forms
- keep local array writes and existing scope behavior unchanged

## Root cause

`MutationTargetResolver` preserves `ArrayDimFetch` targets, but `NeverModifyGloballyDeclaredVariablesRule` only matched plain variable nodes. The rule now unwraps dimension chains to their base variable before matching the active global bindings.

## Verification

- PHPUnit: 35 tests, 48 assertions
- issue-15 regression: 9 `modify.global` diagnostics on the expected lines
- documented PHPStan manual fixtures: expected counts 3/5/9/19, 9/19, and 3/2/2/4

Closes #15