### PR TITLE
Fix dynamic global declaration detection

### DIFF
--- a/src/Rules/GlobalVariableNameResolver.php
+++ b/src/Rules/GlobalVariableNameResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AccessingGlobals\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+
+final class GlobalVariableNameResolver
+{
+    public static function resolve(Node\Expr\Variable $variable, Scope $scope): ?string
+    {
+        if (is_string($variable->name)) {
+            return $variable->name;
+        }
+
+        $constantStrings = $scope->getType($variable->name)->getConstantStrings();
+        if (count($constantStrings) !== 1) {
+            return null;
+        }
+
+        return $constantStrings[0]->getValue();
+    }
+}

--- a/src/Rules/NeverAccessGlobalsRule.php
+++ b/src/Rules/NeverAccessGlobalsRule.php
@@ -26,13 +26,24 @@ class NeverAccessGlobalsRule implements Rule
     {
         $errors = [];
         foreach ($node->vars as $var) {
-            if (!$var instanceof Node\Expr\Variable || !is_string($var->name)) {
+            if (!$var instanceof Node\Expr\Variable) {
                 continue;
             }
+
+            $name = GlobalVariableNameResolver::resolve($var, $scope);
+            if ($name === null) {
+                $errors[] = RuleErrorBuilder::message(
+                    'Code is accessing a global variable with a dynamic name. Use dependency injection instead.',
+                )
+                    ->identifier("access.global")
+                    ->build();
+                continue;
+            }
+
             $errors[] = RuleErrorBuilder::message(
                 sprintf(
                     'Code is accessing global variable $%s. Use dependency injection instead.',
-                    $var->name,
+                    $name,
                 ),
             )
                 ->identifier("access.global")

--- a/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
+++ b/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
@@ -38,16 +38,16 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
     {
         $errors = [];
 
-        // Collect all globally declared variable names
+        // Collect all globally declared variable bindings.
         $globalVars = [];
-        $this->collectGlobalDeclarations($node, $globalVars);
+        $this->collectGlobalDeclarations($node, $scope, $globalVars);
 
         if (empty($globalVars)) {
             return [];
         }
 
-        // Find all assignments to those variables
-        $this->findAssignmentsToGlobals($node, $globalVars, $errors);
+        // Find all assignments to those bindings.
+        $this->findAssignmentsToGlobals($node, $scope, $globalVars, $errors);
 
         return $errors;
     }
@@ -56,19 +56,25 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
      * Traverse the function to collect all global variable declarations.
      *
      * @param Node\FunctionLike $function
-     * @param array<string> $globalVars
+     * @param array<string|null> $globalVars
      */
-    private function collectGlobalDeclarations(Node\FunctionLike $function, array &$globalVars): void
-    {
+    private function collectGlobalDeclarations(
+        Node\FunctionLike $function,
+        Scope $scope,
+        array &$globalVars,
+    ): void {
         $traverser = new NodeTraverser();
-        $visitor = new class($globalVars) extends NodeVisitorAbstract {
-            /** @var array<string> */
+        $visitor = new class($globalVars, $scope) extends NodeVisitorAbstract {
+            /** @var array<string|null> */
             private array $globalVars;
 
-            /** @param array<string> $globalVars */
-            public function __construct(array &$globalVars)
+            private Scope $scope;
+
+            /** @param array<string|null> $globalVars */
+            public function __construct(array &$globalVars, Scope $scope)
             {
                 $this->globalVars = &$globalVars;
+                $this->scope = $scope;
             }
 
             public function enterNode(Node $node)
@@ -80,8 +86,8 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
                 }
                 if ($node instanceof Node\Stmt\Global_) {
                     foreach ($node->vars as $var) {
-                        if ($var instanceof Node\Expr\Variable && is_string($var->name)) {
-                            $this->globalVars[] = $var->name;
+                        if ($var instanceof Node\Expr\Variable) {
+                            $this->globalVars[] = GlobalVariableNameResolver::resolve($var, $this->scope);
                         }
                     }
                 }
@@ -97,29 +103,33 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
      * Traverse the function to find mutations of globally declared variables.
      *
      * @param Node\FunctionLike $function
-     * @param array<string> $globalVars
+     * @param array<string|null> $globalVars
      * @param array<\PHPStan\Rules\RuleError> $errors
      */
     private function findAssignmentsToGlobals(
         Node\FunctionLike $function,
+        Scope $scope,
         array $globalVars,
         array &$errors
     ): void {
         $traverser = new NodeTraverser();
-        $visitor = new class($globalVars, $errors) extends NodeVisitorAbstract {
-            /** @var list<array<string>> */
+        $visitor = new class($globalVars, $scope, $errors) extends NodeVisitorAbstract {
+            /** @var list<array<string|null>> */
             private array $bindingStack;
+
+            private Scope $scope;
 
             /** @var array<\PHPStan\Rules\RuleError> */
             private array $errors;
 
             /**
-             * @param array<string> $globalVars
+             * @param array<string|null> $globalVars
              * @param array<\PHPStan\Rules\RuleError> $errors
              */
-            public function __construct(array $globalVars, array &$errors)
+            public function __construct(array $globalVars, Scope $scope, array &$errors)
             {
                 $this->bindingStack = [$globalVars];
+                $this->scope = $scope;
                 $this->errors = &$errors;
             }
 
@@ -148,16 +158,28 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
                         $globalTarget = $globalTarget->var;
                     }
 
-                    if (
-                        $globalTarget instanceof Node\Expr\Variable &&
-                        is_string($globalTarget->name) &&
-                        in_array($globalTarget->name, $this->currentGlobals(), true)
-                    ) {
-                        $this->errors[] = RuleErrorBuilder::message(
-                            sprintf(
+                    if (!$globalTarget instanceof Node\Expr\Variable) {
+                        continue;
+                    }
+
+                    $targetName = GlobalVariableNameResolver::resolve($globalTarget, $this->scope);
+                    // A null binding represents an unresolved dynamic name. Match
+                    // only another unresolved target and keep its diagnostic generic.
+                    $matchesKnownBinding = $targetName !== null
+                        && in_array($targetName, $this->currentGlobals(), true);
+                    $matchesDynamicBinding = $targetName === null
+                        && in_array(null, $this->currentGlobals(), true);
+
+                    if ($matchesKnownBinding || $matchesDynamicBinding) {
+                        $message = $targetName === null
+                            ? 'Code is modifying a variable with a dynamic name that was declared with the "global" keyword. Use dependency injection instead.'
+                            : sprintf(
                                 'Code is modifying variable $%s that was declared with the "global" keyword. Use dependency injection instead.',
-                                $globalTarget->name,
-                            ),
+                                $targetName,
+                            );
+
+                        $this->errors[] = RuleErrorBuilder::message(
+                            $message,
                         )
                             ->line($node->getLine())
                             ->identifier("modify.global")
@@ -177,7 +199,7 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
             }
 
             /**
-             * @return array<string>
+             * @return array<string|null>
              */
             private function currentGlobals(): array
             {
@@ -185,7 +207,7 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
             }
 
             /**
-             * @return array<string>
+             * @return array<string|null>
              */
             private function bindingsForNested(Node\FunctionLike $node): array
             {

--- a/tests/Rules/Data/issue-16-constant-dynamic-global.php
+++ b/tests/Rules/Data/issue-16-constant-dynamic-global.php
@@ -1,0 +1,9 @@
+<?php
+
+const ISSUE_16_GLOBAL_NAME = 'db';
+
+function issue16ConstantDynamicGlobal(): void
+{
+    global ${ISSUE_16_GLOBAL_NAME};
+    $db = new stdClass();
+}

--- a/tests/Rules/Data/issue-16-literal-dynamic-global.php
+++ b/tests/Rules/Data/issue-16-literal-dynamic-global.php
@@ -1,0 +1,7 @@
+<?php
+
+function issue16LiteralDynamicGlobal(): void
+{
+    global ${'db'};
+    ${'db'} = new stdClass();
+}

--- a/tests/Rules/Data/issue-16-runtime-dynamic-global.php
+++ b/tests/Rules/Data/issue-16-runtime-dynamic-global.php
@@ -1,0 +1,8 @@
+<?php
+
+function issue16RuntimeDynamicGlobal(string $name): void
+{
+    global $$name;
+    $$name = new stdClass();
+    $local = new stdClass();
+}

--- a/tests/Rules/NeverAccessGlobalsRuleTest.php
+++ b/tests/Rules/NeverAccessGlobalsRuleTest.php
@@ -38,4 +38,43 @@ class NeverAccessGlobalsRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testIssue16LiteralDynamicGlobalDeclaration(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-16-literal-dynamic-global.php"],
+            [
+                [
+                    'Code is accessing global variable $db. Use dependency injection instead.',
+                    5,
+                ],
+            ],
+        );
+    }
+
+    public function testIssue16RuntimeDynamicGlobalDeclaration(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-16-runtime-dynamic-global.php"],
+            [
+                [
+                    'Code is accessing a global variable with a dynamic name. Use dependency injection instead.',
+                    5,
+                ],
+            ],
+        );
+    }
+
+    public function testIssue16ConstantDynamicGlobalDeclaration(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-16-constant-dynamic-global.php"],
+            [
+                [
+                    'Code is accessing global variable $db. Use dependency injection instead.',
+                    7,
+                ],
+            ],
+        );
+    }
 }

--- a/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
+++ b/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
@@ -214,4 +214,43 @@ class NeverModifyGloballyDeclaredVariablesRuleTest extends RuleTestCase
             [],
         );
     }
+
+    public function testIssue16LiteralDynamicGlobalDeclaration(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-16-literal-dynamic-global.php"],
+            [
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    6,
+                ],
+            ],
+        );
+    }
+
+    public function testIssue16RuntimeDynamicGlobalDeclaration(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-16-runtime-dynamic-global.php"],
+            [
+                [
+                    'Code is modifying a variable with a dynamic name that was declared with the "global" keyword. Use dependency injection instead.',
+                    6,
+                ],
+            ],
+        );
+    }
+
+    public function testIssue16ConstantDynamicGlobalDeclaration(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-16-constant-dynamic-global.php"],
+            [
+                [
+                    'Code is modifying variable $db that was declared with the "global" keyword. Use dependency injection instead.',
+                    8,
+                ],
+            ],
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Normalize literal and constant dynamic global names before reporting or collecting bindings.
- Report unresolved runtime dynamic declarations and matching dynamic writes with generic diagnostics.
- Add regression coverage for literal, constant, and runtime forms, including the issue reproducer.

## Validation

- PHPUnit: 41 tests, 54 assertions.
- Default ruleset: six expected issue-16 diagnostics with `access.global`/`modify.global` identifiers.

Closes #16