### PR TITLE
fix: resolve namespaced impure function calls

### DIFF
--- a/src/Rules/ForbidImpureGlobalFunctionsRule.php
+++ b/src/Rules/ForbidImpureGlobalFunctionsRule.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
@@ -21,7 +22,9 @@ class ForbidImpureGlobalFunctionsRule implements Rule
      */
     private array $impureFunctions;
 
-    public function __construct()
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+    )
     {
         // A list of common PHP functions that are "impure" because they
         // depend on external state (e.g., system clock, environment, filesystem).
@@ -96,7 +99,13 @@ class ForbidImpureGlobalFunctionsRule implements Rule
             return [];
         }
 
-        $functionName = $node->name->toLowerString();
+        $resolvedFunctionName = $this->reflectionProvider->resolveFunctionName($node->name, $scope);
+
+        if ($resolvedFunctionName === null) {
+            return [];
+        }
+
+        $functionName = strtolower($resolvedFunctionName);
 
         if (isset($this->impureFunctions[$functionName])) {
             return [

--- a/tests/Rules/Data/issue-21-function-resolution.php
+++ b/tests/Rules/Data/issue-21-function-resolution.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AccessingGlobals\Tests\Rules\Data\Issue21;
+
+use function time as importedGlobalTime;
+
+function time(): int
+{
+    return 42;
+}
+
+function callsNamespacedFunction(): int
+{
+    return time();
+}
+
+function callsExplicitGlobalFunction(): int
+{
+    return \time();
+}
+
+function callsImportedGlobalFunction(): int
+{
+    return importedGlobalTime();
+}

--- a/tests/Rules/Data/issue-21-namespaced-function-shadow.php
+++ b/tests/Rules/Data/issue-21-namespaced-function-shadow.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Exploratory\FunctionShadow;
+
+function time(): int
+{
+    return 42;
+}
+
+function callsLocalFunction(): int
+{
+    return time();
+}

--- a/tests/Rules/ForbidImpureGlobalFunctionsRuleTest.php
+++ b/tests/Rules/ForbidImpureGlobalFunctionsRuleTest.php
@@ -15,7 +15,7 @@ class ForbidImpureGlobalFunctionsRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
-        return new ForbidImpureGlobalFunctionsRule();
+        return new ForbidImpureGlobalFunctionsRule(self::createReflectionProvider());
     }
 
     public function testRule(): void
@@ -54,6 +54,39 @@ class ForbidImpureGlobalFunctionsRuleTest extends RuleTestCase
                 ],
                 [
                     'Code is calling the impure function "rand()". This creates a hidden dependency on external state; pass the result as an argument instead.',
+                    26,
+                ],
+            ],
+        );
+    }
+
+    public function testIssue21NamespacedFunctionShadow(): void
+    {
+        // RuleTestCase analyzes fixtures in isolation, so load the declaration
+        // first for ReflectionProvider to resolve the function as the CLI does.
+        require_once __DIR__ . "/Data/issue-21-namespaced-function-shadow.php";
+
+        $this->analyse(
+            [__DIR__ . "/Data/issue-21-namespaced-function-shadow.php"],
+            [],
+        );
+    }
+
+    public function testIssue21NamespacedFunctionResolution(): void
+    {
+        // RuleTestCase analyzes fixtures in isolation, so load the declaration
+        // first for ReflectionProvider to resolve the function as the CLI does.
+        require_once __DIR__ . "/Data/issue-21-function-resolution.php";
+
+        $this->analyse(
+            [__DIR__ . "/Data/issue-21-function-resolution.php"],
+            [
+                [
+                    'Code is calling the impure function "time()". This creates a hidden dependency on external state; pass the result as an argument instead.',
+                    21,
+                ],
+                [
+                    'Code is calling the impure function "time()". This creates a hidden dependency on external state; pass the result as an argument instead.',
                     26,
                 ],
             ],


### PR DESCRIPTION
Fixes #21

## Summary

- Resolve function calls through PHPStan ReflectionProvider before checking the impure-global list.
- Preserve diagnostics for global fallback calls, explicit global calls, and imported global aliases.
- Add regression fixtures for namespaced shadowing and global resolution controls.

## Root cause

The rule compared the lexical AST name, so an unqualified call to a namespaced user-defined function named like an impure PHP builtin was treated as the global builtin.

## Testing

- `vendor/bin/phpunit` — 43 tests, 56 assertions pass.
- The original namespaced-shadow repro now exits 0; control fixtures retain their expected diagnostics.