### PR TITLE
Fix object-property mutations on global bindings

### DIFF
--- a/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
+++ b/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
@@ -154,7 +154,10 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
                     }
 
                     $globalTarget = $target;
-                    while ($globalTarget instanceof Node\Expr\ArrayDimFetch) {
+                    while (
+                        $globalTarget instanceof Node\Expr\ArrayDimFetch
+                        || $globalTarget instanceof Node\Expr\PropertyFetch
+                    ) {
                         $globalTarget = $globalTarget->var;
                     }
 

--- a/tests/Rules/Data/issue-22-property-mutation.php
+++ b/tests/Rules/Data/issue-22-property-mutation.php
@@ -1,0 +1,10 @@
+<?php
+
+function mutatePropertyOnGlobalObject(): void
+{
+    global $box;
+
+    $box->value = 1;
+    $box->value += 1;
+    unset($box->value);
+}

--- a/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
+++ b/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
@@ -253,4 +253,25 @@ class NeverModifyGloballyDeclaredVariablesRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testIssue22ObjectPropertyMutationForms(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-22-property-mutation.php"],
+            [
+                [
+                    'Code is modifying variable $box that was declared with the "global" keyword. Use dependency injection instead.',
+                    7,
+                ],
+                [
+                    'Code is modifying variable $box that was declared with the "global" keyword. Use dependency injection instead.',
+                    8,
+                ],
+                [
+                    'Code is modifying variable $box that was declared with the "global" keyword. Use dependency injection instead.',
+                    9,
+                ],
+            ],
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Detect object-property mutations through variables declared with `global`.
- Cover direct assignment, compound assignment, and `unset` property mutations.

The confirmed root cause was that mutation-target normalization unwrapped `ArrayDimFetch` nodes but skipped `PropertyFetch` nodes.

## Testing

- PHPUnit: 44 tests, 57 assertions passed.
- PHPStan reproducer: exits 1 with the existing `access.global` diagnostic and three `modify.global` diagnostics for the property mutations.

Fixes #22