### PR TITLE
fix: detect dynamic constant() lookups in ForbidUsingGlobalConstants

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This extension provides a set of rules to enforce restrictions on accessing and 
 
 The extension also includes a more "opinionated" set of rules for teams that want to enforce a stricter, more functional style of programming:
 
--   **`ForbidUsingGlobalConstants`**: Prevents functions from accessing global constants (`define()` or `const`), forcing them to be passed as arguments.
+-   **`ForbidUsingGlobalConstants`**: Prevents functions from accessing global constants (`define()` or `const`), forcing them to be passed as arguments. This also covers dynamic lookups via `constant()`: a literal name is reported like a plain constant fetch, and a dynamic name is reported conservatively since it may resolve to a global constant.
 -   **`ForbidUsingStaticProperties`**: Prevents access to static properties, which are a form of global state.
 -   **`ForbidUsingClassConstants`**: Prevents a function from accessing a constant on another class, enforcing that the value should be passed in.
 -   **`ForbidImpureGlobalFunctions`**: Flags calls to impure global functions like `time()`, `getenv()`, or `rand()` that produce side effects or rely on hidden external state.
@@ -203,6 +203,11 @@ class Config {
 // ❌ BAD: ForbidUsingGlobalConstants
 function callApi(): void {
     $key = API_KEY;  // Hidden dependency on global constant
+}
+
+// ❌ BAD: ForbidUsingGlobalConstants (via constant())
+function readMode(): string {
+    return constant('APP_MODE');  // Same hidden dependency, dynamic form
 }
 
 // ❌ BAD: ForbidUsingStaticProperties

--- a/src/Rules/ForbidUsingGlobalConstantsRule.php
+++ b/src/Rules/ForbidUsingGlobalConstantsRule.php
@@ -5,22 +5,32 @@ declare(strict_types=1);
 namespace AccessingGlobals\Rules;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
- * @implements Rule<Node\Expr\ConstFetch>
+ * @implements Rule<Node\Expr>
  */
 class ForbidUsingGlobalConstantsRule implements Rule
 {
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+    )
+    {
+    }
+
     public function getNodeType(): string
     {
-        return Node\Expr\ConstFetch::class;
+        return Node\Expr::class;
     }
 
     /**
-     * @param Node\Expr\ConstFetch $node
+     * @param Node\Expr $node
      */
     public function processNode(Node $node, Scope $scope): array
     {
@@ -31,6 +41,19 @@ class ForbidUsingGlobalConstantsRule implements Rule
             return [];
         }
 
+        if ($node instanceof Node\Expr\ConstFetch) {
+            return $this->processConstFetch($node);
+        }
+
+        if ($node instanceof FuncCall) {
+            return $this->processConstantFunctionCall($node, $scope);
+        }
+
+        return [];
+    }
+
+    private function processConstFetch(Node\Expr\ConstFetch $node): array
+    {
         $constantName = $node->name->toString();
         $lowerCaseConstantName = strtolower($constantName);
 
@@ -42,14 +65,70 @@ class ForbidUsingGlobalConstantsRule implements Rule
         // If we're here, it's a user-defined global constant.
         // This is a hidden dependency and should be passed as an argument instead.
         return [
+            $this->buildGlobalConstantError($constantName),
+        ];
+    }
+
+    /**
+     * constant() can read a global constant without a ConstFetch node, e.g.
+     * constant('MY_CONSTANT'). The name may even be fully dynamic, so flag
+     * conservatively whenever a builtin constant() lookup happens.
+     */
+    private function processConstantFunctionCall(FuncCall $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Name) {
+            // Dynamic function calls like `$functionName()`.
+            return [];
+        }
+
+        $resolvedFunctionName = $this->reflectionProvider->resolveFunctionName($node->name, $scope);
+
+        if ($resolvedFunctionName === null || strtolower($resolvedFunctionName) !== 'constant') {
+            return [];
+        }
+
+        $args = $node->getArgs();
+
+        if (count($args) === 0) {
+            return [];
+        }
+
+        $constantNameArgument = $args[0]->value;
+
+        if ($constantNameArgument instanceof Node\Scalar\String_) {
+            $constantName = $constantNameArgument->value;
+
+            // constant('Foo::BAR') reads a class constant (PHP 8.3+);
+            // ForbidUsingClassConstantsRule covers that case.
+            if (str_contains($constantName, '::')) {
+                return [];
+            }
+
+            return [
+                $this->buildGlobalConstantError($constantName),
+            ];
+        }
+
+        // The name is not statically known; the lookup may still resolve to a
+        // global constant, so report a conservative diagnostic.
+        return [
             RuleErrorBuilder::message(
-                sprintf(
-                    'Code is accessing global constant "%s". Pass it as an argument instead to make the dependency explicit.',
-                    $constantName
-                )
+                'Code is calling constant() with a dynamic constant name, which may read a global constant. Pass the value as an argument instead to make the dependency explicit.'
             )
-                ->identifier('constant.global')
+                ->identifier('constant.dynamic')
                 ->build(),
         ];
+    }
+
+    private function buildGlobalConstantError(string $constantName): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message(
+            sprintf(
+                'Code is accessing global constant "%s". Pass it as an argument instead to make the dependency explicit.',
+                $constantName
+            )
+        )
+            ->identifier('constant.global')
+            ->build();
     }
 }

--- a/tests/Rules/Data/issue-23-constant-edge-cases.php
+++ b/tests/Rules/Data/issue-23-constant-edge-cases.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace AccessingGlobals\Tests\Rules\Data\Issue23Shadow;
+
+const ISSUE_TWENTY_THREE_EDGE_CONST = 'edge';
+
+function shadowedConstant(string $name): string
+{
+    // Not PHP's builtin constant(): this namespace declares its own.
+    return constant($name);
+}
+
+function constant(string $name): string
+{
+    return 'shadowed';
+}
+
+namespace AccessingGlobals\Tests\Rules\Data\Issue23Edge;
+
+use function constant;
+
+const ISSUE_TWENTY_THREE_EDGE_CONST = 'edge';
+
+function readsClassConstantViaConstant(): string
+{
+    // constant('Foo::BAR') reads a class constant, not a global one.
+    return constant('Some\Other\Class::ISSUE_TWENTY_THREE_CLASS_CONST');
+}
+
+function readsGlobalConstantFullyQualified(): string
+{
+    // The fully qualified form is still PHP's builtin constant().
+    return \constant('ISSUE_TWENTY_THREE_EDGE_CONST');
+}

--- a/tests/Rules/Data/issue-23-dynamic-constant-lookup.php
+++ b/tests/Rules/Data/issue-23-dynamic-constant-lookup.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AccessingGlobals\Tests\Rules\Data;
+
+define('ISSUE_TWENTY_THREE_CONST', 'production');
+
+// Reading a global constant through constant() in the root scope is fine.
+$a = constant('ISSUE_TWENTY_THREE_CONST');
+
+// Reading a global constant through constant() inside a function is a hidden
+// dependency, just like a plain constant fetch, and should be flagged.
+function readsGlobalConstantDynamically(): string
+{
+    return constant('ISSUE_TWENTY_THREE_CONST');
+}
+
+// A dynamic constant name cannot be resolved statically; this should still be
+// flagged conservatively.
+function readsGlobalConstantWithDynamicName(string $name): string
+{
+    return constant($name);
+}

--- a/tests/Rules/ForbidUsingGlobalConstantsRuleTest.php
+++ b/tests/Rules/ForbidUsingGlobalConstantsRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AccessingGlobals\Tests\Rules;
 
 use AccessingGlobals\Rules\ForbidUsingGlobalConstantsRule;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -15,7 +16,7 @@ class ForbidUsingGlobalConstantsRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
-        return new ForbidUsingGlobalConstantsRule();
+        return new ForbidUsingGlobalConstantsRule(self::createReflectionProvider());
     }
 
     public function testRule(): void
@@ -34,6 +35,40 @@ class ForbidUsingGlobalConstantsRuleTest extends RuleTestCase
                 [
                     'Code is accessing global constant "MY_CONSTANT". Pass it as an argument instead to make the dependency explicit.',
                     27,
+                ],
+            ],
+        );
+    }
+
+    public function testIssue23DynamicConstantLookups(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-23-dynamic-constant-lookup.php"],
+            [
+                [
+                    'Code is accessing global constant "ISSUE_TWENTY_THREE_CONST". Pass it as an argument instead to make the dependency explicit.',
+                    14,
+                ],
+                [
+                    'Code is calling constant() with a dynamic constant name, which may read a global constant. Pass the value as an argument instead to make the dependency explicit.',
+                    21,
+                ],
+            ],
+        );
+    }
+
+    public function testIssue23ConstantEdgeCases(): void
+    {
+        // RuleTestCase analyzes fixtures in isolation, so load the declaration
+        // first for ReflectionProvider to resolve the function as the CLI does.
+        require_once __DIR__ . "/Data/issue-23-constant-edge-cases.php";
+
+        $this->analyse(
+            [__DIR__ . "/Data/issue-23-constant-edge-cases.php"],
+            [
+                [
+                    'Code is accessing global constant "ISSUE_TWENTY_THREE_EDGE_CONST". Pass it as an argument instead to make the dependency explicit.',
+                    33,
                 ],
             ],
         );


### PR DESCRIPTION
## Summary

`ForbidUsingGlobalConstantsRule` was registered only for `Node\Expr\ConstFetch`, so a function reading a global constant through PHP's `constant()` builtin — a `FuncCall` — never reached the rule and passed silently (issue #23).

## Root cause

Confirmed by a red-capable `RuleTestCase` against the issue's reproducer: the rule's `getNodeType()` returned `ConstFetch::class`, so the analyser never dispatched `FuncCall` nodes to it. `ForbidImpureGlobalFunctionsRule` sees `FuncCall`s but does not list `constant`, so the lookup was invisible to the complete opinionated ruleset.

## Fix

The rule now registers for `Node\Expr` and dispatches inside `processNode`:

- `ConstFetch` handling is unchanged.
- `FuncCall` nodes whose name resolves (via `ReflectionProvider`, as `ForbidImpureGlobalFunctionsRule` does) to PHP's builtin `constant()`:
  - literal name → `constant.global` with the same message as a plain constant fetch;
  - dynamic name → conservative `constant.dynamic` diagnostic, since the lookup may resolve to a global constant;
  - `constant('Foo::BAR')` class-constant form → skipped, left to `ForbidUsingClassConstantsRule` (PHP 8.3+ behaviour);
  - namespaced `constant()` shadows → not flagged.

## Testing

- New regression tests: `testIssue23DynamicConstantLookups` and `testIssue23ConstantEdgeCases` (namespace shadow, `Foo::BAR` skip, fully-qualified `\constant()`).
- Full suite green: 46 tests, 59 assertions.
- CLI repro from the issue now exits 1 with 2 errors (`constant.global`, `constant.dynamic`).
- All CLAUDE.md opinionated-fixture counts unchanged (3 / 2 / 2 / 4).

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)