### PR TITLE
fix: detect by-reference foreach mutation of superglobals

### DIFF
--- a/src/Rules/MutationTargetResolver.php
+++ b/src/Rules/MutationTargetResolver.php
@@ -28,6 +28,12 @@ final class MutationTargetResolver
             $targets = $node->vars;
         } elseif ($node instanceof Node\Stmt\Foreach_) {
             $targets = [$node->valueVar];
+            if ($node->byRef) {
+                // With `foreach ($container as &$value)`, writes to $value
+                // alias into the container, so the container itself is a
+                // mutation target.
+                $targets[] = $node->expr;
+            }
         } elseif (
             !$node instanceof Node\Expr\Assign &&
             !$node instanceof Node\Expr\AssignOp &&

--- a/tests/Rules/Data/issue-24-by-reference-foreach.php
+++ b/tests/Rules/Data/issue-24-by-reference-foreach.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+function mutateSuperglobalElementsByReference(): void
+{
+    foreach ($_SESSION as &$value) {
+        $value = 'changed';
+    }
+}
+
+function mutateGlobalsElementsByReference(): void
+{
+    foreach ($GLOBALS as &$pair) {
+        $pair = 'changed';
+    }
+}
+
+function mutateServerByKeyAndReference(): void
+{
+    foreach ($_SERVER as $key => &$config) {
+        $config = 'changed';
+    }
+}
+
+foreach ($_GET as &$setting) {
+    $setting = 'changed';
+}
+
+function iterateSuperglobalWithoutReference(): void
+{
+    foreach ($_COOKIE as $cookie) {
+    }
+}
+
+function iterateLocalArrayByReference(array $config): void
+{
+    foreach ($config as &$value) {
+        $value = 'changed';
+    }
+}

--- a/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
@@ -162,6 +162,37 @@ class NeverModifySuperGlobalsInNestedScopeRuleTest extends RuleTestCase
         );
     }
 
+    public function testIssue24ByReferenceForeachTargetsOnlyInNestedScope(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-24-by-reference-foreach.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_SESSION in a nested scope. Return the new value instead.',
+                    7,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS in a nested scope. Return the new value instead.',
+                    14,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SERVER in a nested scope. Return the new value instead.',
+                    21,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 3, 'modify.superglobal.nested'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
+
     public function testIssue14UnsetSuperglobalKey(): void
     {
         $this->analyse(

--- a/tests/Rules/NeverModifySuperGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsRuleTest.php
@@ -218,6 +218,41 @@ class NeverModifySuperGlobalsRuleTest extends RuleTestCase
         );
     }
 
+    public function testIssue24ByReferenceForeachTargets(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-24-by-reference-foreach.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    7,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    14,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SERVER. Return the new value instead.',
+                    21,
+                ],
+                [
+                    'Code is modifying superglobal variable $_GET. Return the new value instead.',
+                    26,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 4, 'modify.superglobal'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
+
     public function testIssue14UnsetTargets(): void
     {
         $fixture = __DIR__ . "/Data/issue-14-unset-coverage.php";


### PR DESCRIPTION
## Summary

`MutationTargetResolver` returned only the foreach `valueVar` as a mutation target. For a by-reference foreach (`foreach ($_SESSION as &$value)`), writes to `$value` alias into the container, so the container itself is mutated — but the superglobal source was never surfaced, and `NeverModifySuperGlobalsRule` / `NeverModifySuperGlobalsInNestedScopeRule` stayed silent.

The resolver now also surfaces the foreach `expr` when `Foreach_::$byRef` is set. All four modify rules consume the resolver, but plain (non-global) containers cannot match their filters, so behaviour is unchanged for local arrays.

## Testing

- New fixture `tests/Rules/Data/issue-24-by-reference-foreach.php` covers by-ref iteration of `$_SESSION`, `$GLOBALS`, `$_SERVER`, key+by-ref form, root scope, and negatives (non-by-ref iteration, by-ref iteration of a local array).
- Regression tests added in `NeverModifySuperGlobalsRuleTest` (`modify.superglobal`) and `NeverModifySuperGlobalsInNestedScopeRuleTest` (`modify.superglobal.nested`).
- Full suite: 48 tests, 63 assertions, green.
- AGENTS.md manual verification counts unchanged: 36 (basic) / 28 (strict) / 13 (opinionated).

Fixes #24