### PR TITLE
fix: detect mutations through by-reference builtins

### DIFF
--- a/config/rules-strict.neon
+++ b/config/rules-strict.neon
@@ -1,5 +1,7 @@
 services:
     -
+        class: AccessingGlobals\Rules\MutationTargetResolver
+    -
         class: AccessingGlobals\Rules\NeverAccessGlobalsRule
         tags:
             - phpstan.rules.rule

--- a/config/rules.neon
+++ b/config/rules.neon
@@ -1,5 +1,7 @@
 services:
     -
+        class: AccessingGlobals\Rules\MutationTargetResolver
+    -
         class: AccessingGlobals\Rules\NeverAccessGlobalsRule
         tags:
             - phpstan.rules.rule

--- a/src/Rules/MutationTargetResolver.php
+++ b/src/Rules/MutationTargetResolver.php
@@ -5,14 +5,21 @@ declare(strict_types=1);
 namespace AccessingGlobals\Rules;
 
 use PhpParser\Node;
+use PHPStan\Analyser\Scope;
 use PHPStan\Node\Expr\NativeTypeExpr;
+use PHPStan\Reflection\ReflectionProvider;
 
 final class MutationTargetResolver
 {
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
     /**
      * @return list<Node\Expr>
      */
-    public static function resolve(Node $node): array
+    public function resolve(Node $node, Scope $scope): array
     {
         // PHPStan emits a synthetic assignment for destructured foreach values.
         // The owning Foreach_ node is the real mutation event; processing both
@@ -34,6 +41,8 @@ final class MutationTargetResolver
                 // mutation target.
                 $targets[] = $node->expr;
             }
+        } elseif ($node instanceof Node\Expr\FuncCall) {
+            return $this->resolveFuncCall($node, $scope);
         } elseif (
             !$node instanceof Node\Expr\Assign &&
             !$node instanceof Node\Expr\AssignOp &&
@@ -57,6 +66,72 @@ final class MutationTargetResolver
         }
 
         return $resolvedTargets;
+    }
+
+    /**
+     * A function whose parameter is declared by-reference mutates the passed
+     * value (e.g. `array_pop($_SESSION['items'])`). Resolve those arguments as
+     * mutation targets, using parameter reflection instead of a hardcoded
+     * function list so ordinary by-value calls are never flagged.
+     *
+     * @return list<Node\Expr>
+     */
+    private function resolveFuncCall(Node\Expr\FuncCall $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Node\Name) {
+            return [];
+        }
+
+        if (!$this->reflectionProvider->hasFunction($node->name, $scope)) {
+            return [];
+        }
+
+        $function = $this->reflectionProvider->getFunction($node->name, $scope);
+
+        $targets = [];
+        foreach ($function->getVariants() as $variant) {
+            $parameters = $variant->getParameters();
+            $parameterCount = count($parameters);
+            $variadicParameter = $variant->isVariadic() && $parameterCount > 0
+                ? $parameters[$parameterCount - 1]
+                : null;
+
+            foreach ($node->getArgs() as $index => $arg) {
+                // Spread arguments have an unknown mapping onto parameters.
+                if ($arg->unpack) {
+                    continue;
+                }
+
+                if ($arg->name !== null) {
+                    $parameter = null;
+                    foreach ($parameters as $candidate) {
+                        if ($candidate->getName() === $arg->name->toString()) {
+                            $parameter = $candidate;
+                            break;
+                        }
+                    }
+                } else {
+                    if ($variadicParameter !== null && $index >= $parameterCount - 1) {
+                        $parameter = $variadicParameter;
+                    } elseif ($index < $parameterCount) {
+                        $parameter = $parameters[$index];
+                    } else {
+                        $parameter = null;
+                    }
+                }
+
+                if ($parameter === null || !$parameter->passedByReference()->yes()) {
+                    continue;
+                }
+
+                // Variants share arguments; report each mutating argument once.
+                if (!in_array($arg->value, $targets, true)) {
+                    $targets[] = $arg->value;
+                }
+            }
+        }
+
+        return $targets;
     }
 
     /**

--- a/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
+++ b/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
@@ -25,6 +25,11 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 class NeverModifyGloballyDeclaredVariablesRule implements Rule
 {
+    public function __construct(
+        private readonly MutationTargetResolver $mutationTargetResolver,
+    ) {
+    }
+
     public function getNodeType(): string
     {
         return Node\FunctionLike::class;
@@ -47,7 +52,7 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
         }
 
         // Find all assignments to those bindings.
-        $this->findAssignmentsToGlobals($node, $scope, $globalVars, $errors);
+        $this->findAssignmentsToGlobals($node, $scope, $globalVars, $errors, $this->mutationTargetResolver);
 
         return $errors;
     }
@@ -110,10 +115,11 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
         Node\FunctionLike $function,
         Scope $scope,
         array $globalVars,
-        array &$errors
+        array &$errors,
+        MutationTargetResolver $mutationTargetResolver,
     ): void {
         $traverser = new NodeTraverser();
-        $visitor = new class($globalVars, $scope, $errors) extends NodeVisitorAbstract {
+        $visitor = new class($globalVars, $scope, $errors, $mutationTargetResolver) extends NodeVisitorAbstract {
             /** @var list<array<string|null>> */
             private array $bindingStack;
 
@@ -122,15 +128,22 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
             /** @var array<\PHPStan\Rules\RuleError> */
             private array $errors;
 
+            private MutationTargetResolver $mutationTargetResolver;
+
             /**
              * @param array<string|null> $globalVars
              * @param array<\PHPStan\Rules\RuleError> $errors
              */
-            public function __construct(array $globalVars, Scope $scope, array &$errors)
-            {
+            public function __construct(
+                array $globalVars,
+                Scope $scope,
+                array &$errors,
+                MutationTargetResolver $mutationTargetResolver,
+            ) {
                 $this->bindingStack = [$globalVars];
                 $this->scope = $scope;
                 $this->errors = &$errors;
+                $this->mutationTargetResolver = $mutationTargetResolver;
             }
 
             public function enterNode(Node $node)
@@ -143,7 +156,7 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
 
                     return null;
                 }
-                foreach (MutationTargetResolver::resolve($node) as $target) {
+                foreach ($this->mutationTargetResolver->resolve($node, $this->scope) as $target) {
                     // `unset($db)` removes the local binding created by
                     // `global $db`; it does not remove the global variable.
                     if (

--- a/src/Rules/NeverModifyGlobalsRule.php
+++ b/src/Rules/NeverModifyGlobalsRule.php
@@ -17,6 +17,11 @@ use PhpParser\Node\Scalar\String_;
  */
 class NeverModifyGlobalsRule implements Rule
 {
+    public function __construct(
+        private readonly MutationTargetResolver $mutationTargetResolver,
+    ) {
+    }
+
     public function getNodeType(): string
     {
         return Node::class;
@@ -29,7 +34,7 @@ class NeverModifyGlobalsRule implements Rule
     {
         $errors = [];
 
-        foreach (MutationTargetResolver::resolve($node) as $target) {
+        foreach ($this->mutationTargetResolver->resolve($node, $scope) as $target) {
             if (!$target instanceof ArrayDimFetch) {
                 continue;
             }

--- a/src/Rules/NeverModifySuperGlobalsInNestedScopeRule.php
+++ b/src/Rules/NeverModifySuperGlobalsInNestedScopeRule.php
@@ -12,6 +12,11 @@ use PHPStan\Rules\RuleErrorBuilder;
 class NeverModifySuperGlobalsInNestedScopeRule extends
     AllowSuperGlobalsInRootScopeRule
 {
+    public function __construct(
+        private readonly MutationTargetResolver $mutationTargetResolver,
+    ) {
+    }
+
     public function getNodeType(): string
     {
         return Node::class;
@@ -27,7 +32,7 @@ class NeverModifySuperGlobalsInNestedScopeRule extends
         }
 
         $errors = [];
-        foreach (MutationTargetResolver::resolve($node) as $target) {
+        foreach ($this->mutationTargetResolver->resolve($node, $scope) as $target) {
             $var = $target;
 
             while ($var instanceof Node\Expr\ArrayDimFetch) {

--- a/src/Rules/NeverModifySuperGlobalsRule.php
+++ b/src/Rules/NeverModifySuperGlobalsRule.php
@@ -15,6 +15,11 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 class NeverModifySuperGlobalsRule implements Rule
 {
+    public function __construct(
+        private readonly MutationTargetResolver $mutationTargetResolver,
+    ) {
+    }
+
     /**
      * @var string[]
      */
@@ -41,7 +46,7 @@ class NeverModifySuperGlobalsRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         $errors = [];
-        foreach (MutationTargetResolver::resolve($node) as $target) {
+        foreach ($this->mutationTargetResolver->resolve($node, $scope) as $target) {
             $var = $target;
 
             while ($var instanceof Node\Expr\ArrayDimFetch) {

--- a/tests/Rules/Data/issue-25-by-reference-builtins.php
+++ b/tests/Rules/Data/issue-25-by-reference-builtins.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+function popSessionItems(): void
+{
+    array_pop($_SESSION['items']);
+}
+
+function shiftGetQueue(): void
+{
+    array_shift($_GET['queue']);
+}
+
+function pushIntoPostList(): void
+{
+    array_push($_POST['list'], 'new-item');
+}
+
+function sortCookieValues(): void
+{
+    sort($_COOKIE['values']);
+}
+
+function castRequestType(): void
+{
+    settype($_REQUEST['id'], 'int');
+}
+
+function popGlobalsItems(): void
+{
+    array_pop($GLOBALS['items']);
+}
+
+function readLocalArray(array $config): void
+{
+    array_pop($config);
+}
+
+function callByValueWithSuperglobal(): void
+{
+    count($_SERVER);
+}
+
+array_pop($_ENV['path']);

--- a/tests/Rules/Data/issue-25-global-keyword-by-reference.php
+++ b/tests/Rules/Data/issue-25-global-keyword-by-reference.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+function popDeclaredItems(): void
+{
+    global $items;
+
+    array_pop($items);
+}
+
+function popUndeclaredLocal(): void
+{
+    $stack = [1, 2, 3];
+
+    array_pop($stack);
+}

--- a/tests/Rules/Data/issue-25-globals-by-reference.php
+++ b/tests/Rules/Data/issue-25-globals-by-reference.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+function popGlobalsConfig(): void
+{
+    array_pop($GLOBALS['config']);
+}

--- a/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
+++ b/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AccessingGlobals\Tests\Rules;
 
+use AccessingGlobals\Rules\MutationTargetResolver;
 use AccessingGlobals\Rules\NeverModifyGloballyDeclaredVariablesRule;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -15,7 +16,9 @@ class NeverModifyGloballyDeclaredVariablesRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
-        return new NeverModifyGloballyDeclaredVariablesRule();
+        return new NeverModifyGloballyDeclaredVariablesRule(
+            new MutationTargetResolver(self::createReflectionProvider()),
+        );
     }
 
     public function testRule(): void
@@ -272,6 +275,29 @@ class NeverModifyGloballyDeclaredVariablesRuleTest extends RuleTestCase
                     9,
                 ],
             ],
+        );
+    }
+
+    public function testIssue25ByReferenceBuiltinOnGlobalKeyword(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-25-global-keyword-by-reference.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying variable $items that was declared with the "global" keyword. Use dependency injection instead.',
+                    9,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 1, 'modify.global'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
         );
     }
 }

--- a/tests/Rules/NeverModifyGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifyGlobalsRuleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AccessingGlobals\Tests\Rules;
 
+use AccessingGlobals\Rules\MutationTargetResolver;
 use AccessingGlobals\Rules\NeverModifyGlobalsRule;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -15,7 +16,9 @@ class NeverModifyGlobalsRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
-        return new NeverModifyGlobalsRule();
+        return new NeverModifyGlobalsRule(
+            new MutationTargetResolver(self::createReflectionProvider()),
+        );
     }
 
     public function testRule(): void
@@ -28,6 +31,27 @@ class NeverModifyGlobalsRuleTest extends RuleTestCase
                     5,
                 ],
             ],
+        );
+    }
+
+    public function testIssue25ByReferenceBuiltinOnGlobals(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-25-globals-by-reference.php"],
+            [
+                [
+                    'Code is modifying global variable through $GLOBALS[\'config\']. Use dependency injection instead.',
+                    7,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 1, 'modify.global'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([__DIR__ . "/Data/issue-25-globals-by-reference.php"]),
+            ),
         );
     }
 

--- a/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AccessingGlobals\Tests\Rules;
 
+use AccessingGlobals\Rules\MutationTargetResolver;
 use AccessingGlobals\Rules\NeverModifySuperGlobalsInNestedScopeRule;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -15,7 +16,9 @@ class NeverModifySuperGlobalsInNestedScopeRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
-        return new NeverModifySuperGlobalsInNestedScopeRule();
+        return new NeverModifySuperGlobalsInNestedScopeRule(
+            new MutationTargetResolver(self::createReflectionProvider()),
+        );
     }
 
     public function testRule(): void
@@ -203,6 +206,49 @@ class NeverModifySuperGlobalsInNestedScopeRuleTest extends RuleTestCase
                     5,
                 ],
             ],
+        );
+    }
+
+    public function testIssue25ByReferenceBuiltinsOnlyInNestedScope(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-25-by-reference-builtins.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_SESSION in a nested scope. Return the new value instead.',
+                    7,
+                ],
+                [
+                    'Code is modifying superglobal variable $_GET in a nested scope. Return the new value instead.',
+                    12,
+                ],
+                [
+                    'Code is modifying superglobal variable $_POST in a nested scope. Return the new value instead.',
+                    17,
+                ],
+                [
+                    'Code is modifying superglobal variable $_COOKIE in a nested scope. Return the new value instead.',
+                    22,
+                ],
+                [
+                    'Code is modifying superglobal variable $_REQUEST in a nested scope. Return the new value instead.',
+                    27,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS in a nested scope. Return the new value instead.',
+                    32,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 6, 'modify.superglobal.nested'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
         );
     }
 

--- a/tests/Rules/NeverModifySuperGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsRuleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AccessingGlobals\Tests\Rules;
 
+use AccessingGlobals\Rules\MutationTargetResolver;
 use AccessingGlobals\Rules\NeverModifySuperGlobalsRule;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -15,7 +16,9 @@ class NeverModifySuperGlobalsRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
-        return new NeverModifySuperGlobalsRule();
+        return new NeverModifySuperGlobalsRule(
+            new MutationTargetResolver(self::createReflectionProvider()),
+        );
     }
 
     public function testRule(): void
@@ -246,6 +249,53 @@ class NeverModifySuperGlobalsRuleTest extends RuleTestCase
 
         $this->assertSame(
             array_fill(0, 4, 'modify.superglobal'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
+
+    public function testIssue25ByReferenceBuiltins(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-25-by-reference-builtins.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    7,
+                ],
+                [
+                    'Code is modifying superglobal variable $_GET. Return the new value instead.',
+                    12,
+                ],
+                [
+                    'Code is modifying superglobal variable $_POST. Return the new value instead.',
+                    17,
+                ],
+                [
+                    'Code is modifying superglobal variable $_COOKIE. Return the new value instead.',
+                    22,
+                ],
+                [
+                    'Code is modifying superglobal variable $_REQUEST. Return the new value instead.',
+                    27,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    32,
+                ],
+                [
+                    'Code is modifying superglobal variable $_ENV. Return the new value instead.',
+                    45,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 7, 'modify.superglobal'),
             array_map(
                 static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
                 $this->gatherAnalyserErrors([$fixture]),


### PR DESCRIPTION
## Summary

`NeverModifySuperGlobalsRule`, `NeverModifySuperGlobalsInNestedScopeRule`, `NeverModifyGlobalsRule`, and `NeverModifyGloballyDeclaredVariablesRule` missed mutations performed by built-in functions that accept their argument by reference, e.g.:

```php
function mutateSuperglobalWithByReferenceBuiltin(): void
{
    array_pop($_SESSION['items']);
}
```

`array_pop()` removes and returns the last element of the passed array, so this mutates `$_SESSION['items']`, but only `access.superglobal` was reported — no `modify.superglobal`.

## Fix

`MutationTargetResolver` now resolves `FuncCall` arguments whose parameter is declared by-reference as mutation targets, using PHPStan's `ReflectionProvider` parameter reflection (`hasFunction`/`getFunction`, variants, `passedByReference`) instead of a hardcoded builtin list, so ordinary by-value calls are never flagged. The resolver is now an injectable service registered in `rules.neon` and `rules-strict.neon`; all four consumer rules receive it and share the fix.

Covered forms include positional, named (`array_shift(queue: $_GET['queue'])`), and variadic by-ref parameters (`array_push($_POST['list'], 'x')`), with spread arguments skipped. Verified `modify.superglobal`, `modify.superglobal.nested`, and `modify.global` identifiers via the CLI rulesets; all AGENTS.md verification counts (36/28/13) unchanged.

Fixes #25

## Testing

- New regression fixtures: `issue-25-by-reference-builtins.php` (positive and negative cases incl. by-value `count($_SERVER)` and local arrays), `issue-25-globals-by-reference.php`, `issue-25-global-keyword-by-reference.php`
- Regression tests added to all four modify-rule test classes; full suite: 52 tests, 71 assertions, green
- `vendor/bin/phpstan analyze` with each ruleset reproduces and now reports the missing identifiers