### PR TITLE
fix: skip dynamic class constant fetches in ForbidUsingClassConstantsRule

### DIFF
--- a/src/Rules/ForbidUsingClassConstantsRule.php
+++ b/src/Rules/ForbidUsingClassConstantsRule.php
@@ -34,9 +34,15 @@ class ForbidUsingClassConstantsRule implements Rule
             return [];
         }
 
+        if (!$node->name instanceof Identifier) {
+            // Dynamic class constant fetches like `Config::{$name}` cannot be resolved
+            // to a specific constant. Skip them silently.
+            return [];
+        }
+
         // The `::class` syntax is not a constant value access, it's a language feature
         // for getting a class's fully qualified name. This is not a hidden dependency.
-        if ($node->name instanceof Identifier && $node->name->toLowerString() === 'class') {
+        if ($node->name->toLowerString() === 'class') {
             return [];
         }
 

--- a/tests/Rules/Data/dynamic-class-constant.php
+++ b/tests/Rules/Data/dynamic-class-constant.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AccessingGlobals\Tests\Rules\Data;
+
+class Config
+{
+    public const TIMEOUT = 30;
+}
+
+class DynamicClassConstantTest
+{
+    public function readDynamicConstant(string $name)
+    {
+        return Config::{$name};
+    }
+
+    public function readDynamicExpr()
+    {
+        return Config::{'TIMEOUT'};
+    }
+}
+
+function readDynamicClassConstant(string $name)
+{
+    return Config::{$name};
+}

--- a/tests/Rules/ForbidUsingClassConstantsRuleTest.php
+++ b/tests/Rules/ForbidUsingClassConstantsRuleTest.php
@@ -47,4 +47,12 @@ class ForbidUsingClassConstantsRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testDynamicClassConstantIsSkipped(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/dynamic-class-constant.php"],
+            [],
+        );
+    }
 }


### PR DESCRIPTION
## Summary

In PHP 8.3+, dynamic class constant access syntax like `Config::{$name}` produces an `Expr` node (such as `Variable`) for `$node->name` on `ClassConstFetch`. `ForbidUsingClassConstantsRule` unconditionally called `$node->name->toString()`, resulting in a fatal internal error:
```
Internal error: Call to undefined method PhpParser\Node\Expr\Variable::toString()
```

## Root cause

`ForbidUsingClassConstantsRule::processNode()` checked `$node->name instanceof Identifier && $node->name->toLowerString() === 'class'` for `::class` syntax, but subsequently assumed `$node->name` was an `Identifier` when calling `$node->name->toString()`.

## Fix

- Guard `$node->name` with `if (!$node->name instanceof Identifier) { return []; }` early in `ForbidUsingClassConstantsRule::processNode()`.
- Dynamic class constant fetches where the constant name cannot be statically resolved are skipped silently with no false positive and no internal crash.
- Normal static constant accesses like `Config::TIMEOUT` continue to be checked and reported as before.

## Sibling rules audit

As requested by issue #32, all sibling rules that inspect member or function name nodes were audited:
- `ForbidUsingStaticPropertiesRule`: already guarded against non-`Identifier` property names (`$node->name instanceof Identifier ? ... : '{expression}'`) and dynamic class targets (`!$classNode instanceof Name`).
- `ForbidUsingGlobalConstantsRule`: processes `ConstFetch` (in PHP syntax, constant names in `ConstFetch` are always static `Name` nodes) and `FuncCall` (which guards `!$node->name instanceof Name`).
- `ForbidImpureGlobalFunctionsRule`: processes `FuncCall` and already guards `!$node->name instanceof Name` before calling `toString()`.
- `NeverAccessSuperGlobalsRule` / `NeverModifySuperGlobalsRule`: already defensively check `is_string($node->name)`.

`ForbidUsingClassConstantsRule` was the sole remaining rule making an unguarded `toString()` call on a dynamic expression node.

## Testing

- Added regression fixture `tests/Rules/Data/dynamic-class-constant.php` exercising dynamic class constant fetches (`Config::{$name}`, `Config::{'TIMEOUT'}`) in both methods and functions.
- Added regression test `testDynamicClassConstantIsSkipped()` in `ForbidUsingClassConstantsRuleTest`.
- Full PHPUnit test suite passes (53 tests, 72 assertions).
- Verified `config/rules-opinionated.neon`, `config/rules-strict.neon`, and `config/rules.neon` manual verification suites produce expected error counts (36 / 28 / 13).

Fixes #32