### PR TITLE
fix: treat foreach key variables as mutation targets (#33)

### DIFF
--- a/src/Rules/MutationTargetResolver.php
+++ b/src/Rules/MutationTargetResolver.php
@@ -35,6 +35,11 @@ final class MutationTargetResolver
             $targets = $node->vars;
         } elseif ($node instanceof Node\Stmt\Foreach_) {
             $targets = [$node->valueVar];
+            if ($node->keyVar !== null) {
+                // `foreach ($data as $k => $v)` writes the current key into
+                // $k on every iteration, just like the value target.
+                $targets[] = $node->keyVar;
+            }
             if ($node->byRef) {
                 // With `foreach ($container as &$value)`, writes to $value
                 // alias into the container, so the container itself is a

--- a/tests/Rules/Data/issue-33-foreach-key-targets.php
+++ b/tests/Rules/Data/issue-33-foreach-key-targets.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+$data = ['a' => 1];
+
+foreach ($data as $_SESSION['key'] => $val) {
+}
+
+foreach ($data as $GLOBALS['key'] => $val) {
+}
+
+function writesGlobalKey(array $data): void
+{
+    global $globalDeclared;
+
+    foreach ($data as $globalDeclared => $val) {
+    }
+
+    foreach ($data as $_POST['key'] => $val) {
+    }
+}

--- a/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
+++ b/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
@@ -300,4 +300,27 @@ class NeverModifyGloballyDeclaredVariablesRuleTest extends RuleTestCase
             ),
         );
     }
+
+    public function testIssue33ForeachKeyTargetGlobalBinding(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-33-foreach-key-targets.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying variable $globalDeclared that was declared with the "global" keyword. Use dependency injection instead.',
+                    17,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 1, 'modify.global'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }

--- a/tests/Rules/NeverModifyGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifyGlobalsRuleTest.php
@@ -126,6 +126,10 @@ class NeverModifyGlobalsRuleTest extends RuleTestCase
                     8,
                 ],
                 [
+                    'Code is modifying global variable through $GLOBALS[\'key\']. Use dependency injection instead.',
+                    11,
+                ],
+                [
                     'Code is modifying global variable through $GLOBALS[\'value\']. Use dependency injection instead.',
                     11,
                 ],
@@ -137,7 +141,7 @@ class NeverModifyGlobalsRuleTest extends RuleTestCase
         );
 
         $this->assertSame(
-            array_fill(0, 4, 'modify.global'),
+            array_fill(0, 5, 'modify.global'),
             array_map(
                 static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
                 $this->gatherAnalyserErrors([$fixture]),
@@ -165,6 +169,29 @@ class NeverModifyGlobalsRuleTest extends RuleTestCase
 
         $this->assertSame(
             array_fill(0, 2, 'modify.global'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
+
+    public function testIssue33ForeachKeyTargets(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-33-foreach-key-targets.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying global variable through $GLOBALS[\'key\']. Use dependency injection instead.',
+                    10,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 1, 'modify.global'),
             array_map(
                 static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
                 $this->gatherAnalyserErrors([$fixture]),

--- a/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
@@ -282,4 +282,27 @@ class NeverModifySuperGlobalsInNestedScopeRuleTest extends RuleTestCase
             ),
         );
     }
+
+    public function testIssue33ForeachKeyTargetsOnlyInNestedScope(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-33-foreach-key-targets.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_POST in a nested scope. Return the new value instead.',
+                    20,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 1, 'modify.superglobal.nested'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }

--- a/tests/Rules/NeverModifySuperGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsRuleTest.php
@@ -190,6 +190,10 @@ class NeverModifySuperGlobalsRuleTest extends RuleTestCase
                     8,
                 ],
                 [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    11,
+                ],
+                [
                     'Code is modifying superglobal variable $_REQUEST. Return the new value instead.',
                     11,
                 ],
@@ -213,7 +217,7 @@ class NeverModifySuperGlobalsRuleTest extends RuleTestCase
         );
 
         $this->assertSame(
-            array_fill(0, 7, 'modify.superglobal'),
+            array_fill(0, 8, 'modify.superglobal'),
             array_map(
                 static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
                 $this->gatherAnalyserErrors([$fixture]),
@@ -335,6 +339,37 @@ class NeverModifySuperGlobalsRuleTest extends RuleTestCase
 
         $this->assertSame(
             array_fill(0, 5, 'modify.superglobal'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
+
+    public function testIssue33ForeachKeyTargets(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-33-foreach-key-targets.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    7,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    10,
+                ],
+                [
+                    'Code is modifying superglobal variable $_POST. Return the new value instead.',
+                    20,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 3, 'modify.superglobal'),
             array_map(
                 static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
                 $this->gatherAnalyserErrors([$fixture]),


### PR DESCRIPTION
Root cause (confirmed hypothesis): MutationTargetResolver's Foreach_
branch only collected valueVar (plus the container for by-ref loops) and
never keyVar, so `foreach ($data as $_SESSION['k'] => $v)`,
`$GLOBALS['k'] =>` and `global`-declared key variables bypassed every
NeverModify* rule. Appending keyVar to the resolved targets fixes all four
rules uniformly without rule-specific changes.

The issue-13 fixtures already contained a `$GLOBALS['key'] =>` target whose
missed diagnostic was baked into their expectations; those are updated.

Closes #33




Tests: new issue-33 fixture + tests across all four NeverModify* rules (red before fix, green after); issue-13 expectations updated for the previously missed `$GLOBALS[key] =>` target; phpunit 57 OK; CLAUDE.md manual totals unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)