### PR TITLE
fix: forbid class constant lookups via constant() (#35)

### DIFF
--- a/src/Rules/ForbidUsingClassConstantsRule.php
+++ b/src/Rules/ForbidUsingClassConstantsRule.php
@@ -6,24 +6,33 @@ namespace AccessingGlobals\Rules;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
- * @implements Rule<ClassConstFetch>
+ * @implements Rule<Node\Expr>
  */
 class ForbidUsingClassConstantsRule implements Rule
 {
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+    )
+    {
+    }
+
     public function getNodeType(): string
     {
-        return ClassConstFetch::class;
+        return Node\Expr::class;
     }
 
     /**
-     * @param ClassConstFetch $node
+     * @param Node\Expr $node
      */
     public function processNode(Node $node, Scope $scope): array
     {
@@ -34,6 +43,19 @@ class ForbidUsingClassConstantsRule implements Rule
             return [];
         }
 
+        if ($node instanceof ClassConstFetch) {
+            return $this->processClassConstFetch($node, $scope);
+        }
+
+        if ($node instanceof FuncCall) {
+            return $this->processConstantFunctionCall($node, $scope);
+        }
+
+        return [];
+    }
+
+    private function processClassConstFetch(ClassConstFetch $node, Scope $scope): array
+    {
         if (!$node->name instanceof Identifier) {
             // Dynamic class constant fetches like `Config::{$name}` cannot be resolved
             // to a specific constant. Skip them silently.
@@ -75,15 +97,85 @@ class ForbidUsingClassConstantsRule implements Rule
         $constantName = $node->name->toString();
 
         return [
-            RuleErrorBuilder::message(
-                sprintf(
-                    'Code is accessing constant %s::%s. This creates a hidden dependency; pass the value as an argument instead.',
-                    $resolvedFetchedClassName,
-                    $constantName
-                )
-            )
-                ->identifier('constant.class')
-                ->build(),
+            $this->buildClassConstantError($resolvedFetchedClassName, $constantName),
         ];
+    }
+
+    private function processConstantFunctionCall(FuncCall $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Name) {
+            // Dynamic function calls like `$functionName()`.
+            return [];
+        }
+
+        $resolvedFunctionName = $this->reflectionProvider->resolveFunctionName($node->name, $scope);
+
+        if ($resolvedFunctionName === null || strtolower($resolvedFunctionName) !== 'constant') {
+            return [];
+        }
+
+        $args = $node->getArgs();
+
+        if (count($args) === 0) {
+            return [];
+        }
+
+        $constantNameArgument = $args[0]->value;
+
+        if (!$constantNameArgument instanceof Node\Scalar\String_) {
+            return [];
+        }
+
+        $constantString = $constantNameArgument->value;
+
+        if (!str_contains($constantString, '::')) {
+            return [];
+        }
+
+        [$className, $constantName] = explode('::', $constantString, 2);
+
+        if ($className === '' || $constantName === '') {
+            return [];
+        }
+
+        if (strtolower($constantName) === 'class') {
+            return [];
+        }
+
+        if (in_array(strtolower($className), ['self', 'parent', 'static'], true)) {
+            return [];
+        }
+
+        $normalizedClassName = ltrim($className, '\\');
+
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection !== null) {
+            $currentClassName = $classReflection->getName();
+
+            if (
+                $normalizedClassName === $currentClassName
+                || str_ends_with($currentClassName, '\\' . $normalizedClassName)
+            ) {
+                return [];
+            }
+        }
+
+        return [
+            $this->buildClassConstantError($normalizedClassName, $constantName),
+        ];
+    }
+
+    private function buildClassConstantError(string $className, string $constantName): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message(
+            sprintf(
+                'Code is accessing constant %s::%s. This creates a hidden dependency; pass the value as an argument instead.',
+                $className,
+                $constantName
+            )
+        )
+            ->identifier('constant.class')
+            ->build();
     }
 }

--- a/tests/Rules/Data/issue-35-constant-class-lookup.php
+++ b/tests/Rules/Data/issue-35-constant-class-lookup.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AccessingGlobals\Tests\Rules\Data\Issue35;
+
+class Config
+{
+    public const TIMEOUT = 30;
+}
+
+class BaseClass
+{
+    public const BASE_TIMEOUT = 10;
+}
+
+class Client extends BaseClass
+{
+    public const OWN_TIMEOUT = 20;
+
+    public function process(): int
+    {
+        // OK: Accessing own constant via constant('self::...')
+        $a = constant('self::OWN_TIMEOUT');
+
+        // OK: Accessing own constant via constant('Client::...')
+        $b = constant('Client::OWN_TIMEOUT');
+
+        // OK: Accessing own constant via fully-qualified name
+        $c = constant('AccessingGlobals\Tests\Rules\Data\Issue35\Client::OWN_TIMEOUT');
+
+        // OK: Accessing parent constant via constant('parent::...')
+        $d = constant('parent::BASE_TIMEOUT');
+
+        // OK: Accessing static constant via constant('static::...')
+        $e = constant('static::OWN_TIMEOUT');
+
+        // BAD: Accessing external class constant inside method
+        $f = constant('Config::TIMEOUT');
+
+        // BAD: Accessing external class constant via fully qualified name inside method
+        $g = constant('AccessingGlobals\Tests\Rules\Data\Issue35\Config::TIMEOUT');
+
+        return $a + $b + $c + $d + $e + $f + $g;
+    }
+}
+
+function doSomething(): int
+{
+    // BAD: Accessing external class constant inside function
+    $timeout = constant('Config::TIMEOUT');
+
+    // BAD: Accessing external class constant via fully qualified name inside function
+    $fqTimeout = constant('AccessingGlobals\Tests\Rules\Data\Issue35\Config::TIMEOUT');
+
+    // OK: Plain global constant should not be flagged by class constants rule
+    $globalVal = constant('PHP_VERSION');
+
+    return $timeout + $fqTimeout;
+}
+
+// OK: Accessing external class constant in root scope is not flagged
+$rootTimeout = constant('Config::TIMEOUT');

--- a/tests/Rules/ForbidUsingClassConstantsRuleTest.php
+++ b/tests/Rules/ForbidUsingClassConstantsRuleTest.php
@@ -15,7 +15,7 @@ class ForbidUsingClassConstantsRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
-        return new ForbidUsingClassConstantsRule();
+        return new ForbidUsingClassConstantsRule(self::createReflectionProvider());
     }
 
     public function testRule(): void
@@ -53,6 +53,31 @@ class ForbidUsingClassConstantsRuleTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . "/Data/dynamic-class-constant.php"],
             [],
+        );
+    }
+
+    public function testIssue35ClassConstantViaConstant(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-35-constant-class-lookup.php"],
+            [
+                [
+                    "Code is accessing constant Config::TIMEOUT. This creates a hidden dependency; pass the value as an argument instead.",
+                    39,
+                ],
+                [
+                    "Code is accessing constant AccessingGlobals\Tests\Rules\Data\Issue35\Config::TIMEOUT. This creates a hidden dependency; pass the value as an argument instead.",
+                    42,
+                ],
+                [
+                    "Code is accessing constant Config::TIMEOUT. This creates a hidden dependency; pass the value as an argument instead.",
+                    51,
+                ],
+                [
+                    "Code is accessing constant AccessingGlobals\Tests\Rules\Data\Issue35\Config::TIMEOUT. This creates a hidden dependency; pass the value as an argument instead.",
+                    54,
+                ],
+            ],
         );
     }
 }


### PR DESCRIPTION
## Summary
Fixes #35 where `constant('Class::CONST')` lookups bypassed both `ForbidUsingGlobalConstantsRule` and `ForbidUsingClassConstantsRule`.

### Root Cause
`ForbidUsingClassConstantsRule` only inspected `ClassConstFetch` AST nodes and did not inspect `FuncCall` nodes. Meanwhile, `ForbidUsingGlobalConstantsRule` explicitly skipped constant lookups where the constant name contains `::`, deferring to class constant rules. As a result, `constant('Class::CONST')` evaded both rules.

### Solution
- Updated `ForbidUsingClassConstantsRule` to implement `Rule<Node\Expr>` so it inspects both `ClassConstFetch` and `FuncCall` nodes.
- When inspecting `constant()` function calls, if the first argument is a string literal containing `::`, split it into class name and constant name, check that it is not `self`, `parent`, or `static` and not the current class itself, and report a `constant.class` error.
- Registered and autowired `ReflectionProvider` in `ForbidUsingClassConstantsRule` to resolve function names.
- Added test fixture `tests/Rules/Data/issue-35-constant-class-lookup.php` and unit test `testIssue35ClassConstantViaConstant`.

Closes #35