### PR TITLE
Fix literal dynamic superglobal detection

### DIFF
--- a/src/Rules/NeverAccessSuperGlobalsInNestedScopeRule.php
+++ b/src/Rules/NeverAccessSuperGlobalsInNestedScopeRule.php
@@ -28,16 +28,17 @@ class NeverAccessSuperGlobalsInNestedScopeRule extends
             return [];
         }
 
-        if (!is_string($node->name)) {
+        $name = GlobalVariableNameResolver::resolve($node, $scope);
+        if ($name === null) {
             return [];
         }
 
-        if (in_array($node->name, $this->superglobals, true)) {
+        if (in_array($name, $this->superglobals, true)) {
             return [
                 RuleErrorBuilder::message(
                     sprintf(
                         'Code is accessing superglobal variable $%s in a nested scope. Pass the value as an argument instead.',
-                        $node->name,
+                        $name,
                     ),
                 )
                     ->identifier("access.superglobal.nested")

--- a/src/Rules/NeverAccessSuperGlobalsRule.php
+++ b/src/Rules/NeverAccessSuperGlobalsRule.php
@@ -39,16 +39,17 @@ class NeverAccessSuperGlobalsRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!is_string($node->name)) {
+        $name = GlobalVariableNameResolver::resolve($node, $scope);
+        if ($name === null) {
             return [];
         }
 
-        if (in_array($node->name, $this->superglobals, true)) {
+        if (in_array($name, $this->superglobals, true)) {
             return [
                 RuleErrorBuilder::message(
                     sprintf(
                         'Code is accessing superglobal variable $%s. Pass the value as an argument instead.',
-                        $node->name,
+                        $name,
                     ),
                 )
                     ->identifier("access.superglobal")

--- a/src/Rules/NeverModifyGlobalsRule.php
+++ b/src/Rules/NeverModifyGlobalsRule.php
@@ -44,10 +44,12 @@ class NeverModifyGlobalsRule implements Rule
                 $globalTarget = $globalTarget->var;
             }
 
-            if (
-                !$globalTarget->var instanceof Variable ||
-                $globalTarget->var->name !== "GLOBALS"
-            ) {
+            if (!$globalTarget->var instanceof Variable) {
+                continue;
+            }
+
+            $name = GlobalVariableNameResolver::resolve($globalTarget->var, $scope);
+            if ($name !== "GLOBALS") {
                 continue;
             }
 

--- a/src/Rules/NeverModifySuperGlobalsInNestedScopeRule.php
+++ b/src/Rules/NeverModifySuperGlobalsInNestedScopeRule.php
@@ -39,15 +39,20 @@ class NeverModifySuperGlobalsInNestedScopeRule extends
                 $var = $var->var;
             }
 
-            if (!$var instanceof Variable || !is_string($var->name)) {
+            if (!$var instanceof Variable) {
                 continue;
             }
 
-            if (in_array($var->name, $this->superglobals, true)) {
+            $name = GlobalVariableNameResolver::resolve($var, $scope);
+            if ($name === null) {
+                continue;
+            }
+
+            if (in_array($name, $this->superglobals, true)) {
                 $errors[] = RuleErrorBuilder::message(
                     sprintf(
                         'Code is modifying superglobal variable $%s in a nested scope. Return the new value instead.',
-                        $var->name,
+                        $name,
                     ),
                 )
                     ->identifier("modify.superglobal.nested")

--- a/src/Rules/NeverModifySuperGlobalsRule.php
+++ b/src/Rules/NeverModifySuperGlobalsRule.php
@@ -53,15 +53,20 @@ class NeverModifySuperGlobalsRule implements Rule
                 $var = $var->var;
             }
 
-            if (!$var instanceof Variable || !is_string($var->name)) {
+            if (!$var instanceof Variable) {
                 continue;
             }
 
-            if (in_array($var->name, $this->superglobals, true)) {
+            $name = GlobalVariableNameResolver::resolve($var, $scope);
+            if ($name === null) {
+                continue;
+            }
+
+            if (in_array($name, $this->superglobals, true)) {
                 $errors[] = RuleErrorBuilder::message(
                     sprintf(
                         'Code is modifying superglobal variable $%s. Return the new value instead.',
-                        $var->name,
+                        $name,
                     ),
                 )
                     ->identifier("modify.superglobal")

--- a/tests/Rules/Data/issue-36-literal-dynamic-superglobals.php
+++ b/tests/Rules/Data/issue-36-literal-dynamic-superglobals.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+function readLiteralDynamicSuperglobal(): mixed
+{
+    return ${'_GET'}['id'];
+}
+
+function mutateLiteralDynamicSuperglobal(): void
+{
+    ${'_SESSION'}['user'] = 'alice';
+}
+
+function mutateLiteralDynamicGlobals(): void
+{
+    ${'GLOBALS'}['cache'] = 'enabled';
+}
+
+function readRuntimeDynamicVariable(string $name): mixed
+{
+    return ${$name}['id'];
+}
+
+function mutateRuntimeDynamicVariable(string $name): void
+{
+    ${$name}['value'] = 'value';
+}

--- a/tests/Rules/NeverAccessSuperGlobalsInNestedScopeRuleTest.php
+++ b/tests/Rules/NeverAccessSuperGlobalsInNestedScopeRuleTest.php
@@ -79,4 +79,25 @@ class NeverAccessSuperGlobalsInNestedScopeRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testIssue36LiteralDynamicNames(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-36-literal-dynamic-superglobals.php"],
+            [
+                [
+                    'Code is accessing superglobal variable $_GET in a nested scope. Pass the value as an argument instead.',
+                    7,
+                ],
+                [
+                    'Code is accessing superglobal variable $_SESSION in a nested scope. Pass the value as an argument instead.',
+                    12,
+                ],
+                [
+                    'Code is accessing superglobal variable $GLOBALS in a nested scope. Pass the value as an argument instead.',
+                    17,
+                ],
+            ],
+        );
+    }
 }

--- a/tests/Rules/NeverAccessSuperGlobalsRuleTest.php
+++ b/tests/Rules/NeverAccessSuperGlobalsRuleTest.php
@@ -62,4 +62,25 @@ class NeverAccessSuperGlobalsRuleTest extends RuleTestCase
             ],
         );
     }
+
+    public function testIssue36LiteralDynamicNames(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-36-literal-dynamic-superglobals.php"],
+            [
+                [
+                    'Code is accessing superglobal variable $_GET. Pass the value as an argument instead.',
+                    7,
+                ],
+                [
+                    'Code is accessing superglobal variable $_SESSION. Pass the value as an argument instead.',
+                    12,
+                ],
+                [
+                    'Code is accessing superglobal variable $GLOBALS. Pass the value as an argument instead.',
+                    17,
+                ],
+            ],
+        );
+    }
 }

--- a/tests/Rules/NeverModifyGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifyGlobalsRuleTest.php
@@ -34,6 +34,19 @@ class NeverModifyGlobalsRuleTest extends RuleTestCase
         );
     }
 
+    public function testIssue36LiteralDynamicGlobals(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-36-literal-dynamic-superglobals.php"],
+            [
+                [
+                    'Code is modifying global variable through $GLOBALS[\'cache\']. Use dependency injection instead.',
+                    17,
+                ],
+            ],
+        );
+    }
+
     public function testIssue25ByReferenceBuiltinOnGlobals(): void
     {
         $this->analyse(

--- a/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
@@ -66,6 +66,23 @@ class NeverModifySuperGlobalsInNestedScopeRuleTest extends RuleTestCase
         );
     }
 
+    public function testIssue36LiteralDynamicNames(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-36-literal-dynamic-superglobals.php"],
+            [
+                [
+                    'Code is modifying superglobal variable $_SESSION in a nested scope. Return the new value instead.',
+                    12,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS in a nested scope. Return the new value instead.',
+                    17,
+                ],
+            ],
+        );
+    }
+
     public function testIssue3MutationFormsOnlyInNestedScope(): void
     {
         $fixture = __DIR__ . "/Data/issue-3-nested-syntax-coverage.php";

--- a/tests/Rules/NeverModifySuperGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsRuleTest.php
@@ -66,6 +66,23 @@ class NeverModifySuperGlobalsRuleTest extends RuleTestCase
         );
     }
 
+    public function testIssue36LiteralDynamicNames(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-36-literal-dynamic-superglobals.php"],
+            [
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    12,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    17,
+                ],
+            ],
+        );
+    }
+
     public function testIssue3MutationForms(): void
     {
         $fixture = __DIR__ . "/Data/issue-3-compound-modifications.php";


### PR DESCRIPTION
## Summary

- Reuse `GlobalVariableNameResolver` for literal dynamic superglobal access and mutation checks.
- Detect writes through `${'GLOBALS'}` while continuing to ignore genuinely runtime-dynamic names.
- Add issue #36 regression coverage for strict, nested, and `$GLOBALS` rules.

## Verification

- `vendor/bin/phpunit` — 75 tests, 155 assertions
- Documented manual PHPStan checks — expected counts passed
- Issue #36 repro loop — 3 consecutive passes under both rule configurations

Fixes #36