### PR TITLE
Fix object-property mutations on superglobals and $GLOBALS

### DIFF
--- a/src/Rules/NeverModifyGlobalsRule.php
+++ b/src/Rules/NeverModifyGlobalsRule.php
@@ -35,16 +35,25 @@ class NeverModifyGlobalsRule implements Rule
         $errors = [];
 
         foreach ($this->mutationTargetResolver->resolve($node, $scope) as $target) {
-            if (!$target instanceof ArrayDimFetch) {
+            if (
+                !$target instanceof ArrayDimFetch
+                && !$target instanceof Node\Expr\PropertyFetch
+            ) {
                 continue;
             }
 
             $globalTarget = $target;
-            while ($globalTarget->var instanceof ArrayDimFetch) {
+            while (
+                $globalTarget->var instanceof ArrayDimFetch
+                || $globalTarget->var instanceof Node\Expr\PropertyFetch
+            ) {
                 $globalTarget = $globalTarget->var;
             }
 
-            if (!$globalTarget->var instanceof Variable) {
+            if (
+                !$globalTarget instanceof ArrayDimFetch
+                || !$globalTarget->var instanceof Variable
+            ) {
                 continue;
             }
 

--- a/src/Rules/NeverModifySuperGlobalsInNestedScopeRule.php
+++ b/src/Rules/NeverModifySuperGlobalsInNestedScopeRule.php
@@ -35,7 +35,10 @@ class NeverModifySuperGlobalsInNestedScopeRule extends
         foreach ($this->mutationTargetResolver->resolve($node, $scope) as $target) {
             $var = $target;
 
-            while ($var instanceof Node\Expr\ArrayDimFetch) {
+            while (
+                $var instanceof Node\Expr\ArrayDimFetch
+                || $var instanceof Node\Expr\PropertyFetch
+            ) {
                 $var = $var->var;
             }
 

--- a/src/Rules/NeverModifySuperGlobalsRule.php
+++ b/src/Rules/NeverModifySuperGlobalsRule.php
@@ -49,7 +49,10 @@ class NeverModifySuperGlobalsRule implements Rule
         foreach ($this->mutationTargetResolver->resolve($node, $scope) as $target) {
             $var = $target;
 
-            while ($var instanceof Node\Expr\ArrayDimFetch) {
+            while (
+                $var instanceof Node\Expr\ArrayDimFetch
+                || $var instanceof Node\Expr\PropertyFetch
+            ) {
                 $var = $var->var;
             }
 

--- a/tests/Rules/Data/issue-42-property-mutation.php
+++ b/tests/Rules/Data/issue-42-property-mutation.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+function mutateSuperglobalProperties(): void
+{
+    $_SESSION['state']->name = 'alice';
+    $_SESSION['state']->count++;
+    unset($_SESSION['state']->name);
+}
+
+function mutateGlobalsProperties(): void
+{
+    $GLOBALS['state']->name = 'bob';
+    $GLOBALS['state']->count++;
+    unset($GLOBALS['state']->name);
+}
+
+// Property writes in root scope are also global mutations.
+$GLOBALS['root']->name = 'root';
+$GLOBALS['root']->count++;
+unset($GLOBALS['root']->name);

--- a/tests/Rules/NeverModifyGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifyGlobalsRuleTest.php
@@ -47,6 +47,49 @@ class NeverModifyGlobalsRuleTest extends RuleTestCase
         );
     }
 
+    public function testIssue42ObjectPropertyMutationForms(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-42-property-mutation.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying global variable through $GLOBALS[\'state\']. Use dependency injection instead.',
+                    14,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'state\']. Use dependency injection instead.',
+                    15,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'state\']. Use dependency injection instead.',
+                    16,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'root\']. Use dependency injection instead.',
+                    20,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'root\']. Use dependency injection instead.',
+                    21,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'root\']. Use dependency injection instead.',
+                    22,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 6, 'modify.global'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
+
     public function testIssue25ByReferenceBuiltinOnGlobals(): void
     {
         $this->analyse(

--- a/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
@@ -83,6 +83,49 @@ class NeverModifySuperGlobalsInNestedScopeRuleTest extends RuleTestCase
         );
     }
 
+    public function testIssue42ObjectPropertyMutationForms(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-42-property-mutation.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_SESSION in a nested scope. Return the new value instead.',
+                    7,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION in a nested scope. Return the new value instead.',
+                    8,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION in a nested scope. Return the new value instead.',
+                    9,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS in a nested scope. Return the new value instead.',
+                    14,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS in a nested scope. Return the new value instead.',
+                    15,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS in a nested scope. Return the new value instead.',
+                    16,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 6, 'modify.superglobal.nested'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
+
     public function testIssue3MutationFormsOnlyInNestedScope(): void
     {
         $fixture = __DIR__ . "/Data/issue-3-nested-syntax-coverage.php";

--- a/tests/Rules/NeverModifySuperGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsRuleTest.php
@@ -83,6 +83,61 @@ class NeverModifySuperGlobalsRuleTest extends RuleTestCase
         );
     }
 
+    public function testIssue42ObjectPropertyMutationForms(): void
+    {
+        $fixture = __DIR__ . "/Data/issue-42-property-mutation.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    7,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    8,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    9,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    14,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    15,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    16,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    20,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    21,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    22,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 9, 'modify.superglobal'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
+
     public function testIssue3MutationForms(): void
     {
         $fixture = __DIR__ . "/Data/issue-3-compound-modifications.php";


### PR DESCRIPTION
## Summary

- Unwrap `PropertyFetch` nodes alongside `ArrayDimFetch` nodes in the superglobal mutation rules.
- Preserve the root `$GLOBALS[...]` array dimension while traversing property chains in `NeverModifyGlobalsRule`.
- Add regression coverage for assignment, compound increment, unset, nested scope, and root-scope mutations.

## Root cause

`MutationTargetResolver` already returned the property-fetch mutation target, but the `NeverModify*` rules stopped at or rejected that node, so object-property mutations bypassed diagnostics.

## Validation

- `vendor/bin/phpunit` — 78 tests, 161 assertions
- Issue #42 repro assertion — repeated 3 times; both configurations exited 1 and reported the expected mutation identifiers and lines
- Documented manual checks — expected exit 1 and counts 36 / 28 / 13

Closes #42