### PR TITLE
Fix method and static calls with by-reference parameters (#43)

### DIFF
--- a/src/Rules/MutationTargetResolver.php
+++ b/src/Rules/MutationTargetResolver.php
@@ -48,6 +48,10 @@ final class MutationTargetResolver
             }
         } elseif ($node instanceof Node\Expr\FuncCall) {
             return $this->resolveFuncCall($node, $scope);
+        } elseif ($node instanceof Node\Expr\MethodCall) {
+            return $this->resolveMethodCall($node, $scope);
+        } elseif ($node instanceof Node\Expr\StaticCall) {
+            return $this->resolveStaticCall($node, $scope);
         } elseif (
             !$node instanceof Node\Expr\Assign &&
             !$node instanceof Node\Expr\AssignOp &&
@@ -93,15 +97,89 @@ final class MutationTargetResolver
 
         $function = $this->reflectionProvider->getFunction($node->name, $scope);
 
+        return $this->resolveParametersAcceptorArguments($function->getVariants(), $node->getArgs());
+    }
+
+    /**
+     * @return list<Node\Expr>
+     */
+    private function resolveMethodCall(
+        Node\Expr\MethodCall $node,
+        Scope $scope,
+    ): array {
+        $methodName = $this->resolveMethodName($node->name, $scope);
+        if ($methodName === null) {
+            return [];
+        }
+
+        $callerType = $scope->getType($node->var);
+        $method = $scope->getMethodReflection($callerType, $methodName);
+        if ($method === null) {
+            return [];
+        }
+
+        return $this->resolveParametersAcceptorArguments($method->getVariants(), $node->getArgs());
+    }
+
+    /**
+     * @return list<Node\Expr>
+     */
+    private function resolveStaticCall(Node\Expr\StaticCall $node, Scope $scope): array
+    {
+        $methodName = $this->resolveMethodName($node->name, $scope);
+        if ($methodName === null) {
+            return [];
+        }
+
+        if ($node->class instanceof Node\Name) {
+            $classType = $scope->resolveTypeByName($node->class);
+        } elseif ($node->class instanceof Node\Expr) {
+            $classType = $scope->getType($node->class);
+            if (!$classType->canCallMethods()->yes()) {
+                $classType = $classType->getClassStringObjectType();
+            }
+        } else {
+            return [];
+        }
+
+        $method = $scope->getMethodReflection($classType, $methodName);
+        if ($method === null) {
+            return [];
+        }
+
+        return $this->resolveParametersAcceptorArguments($method->getVariants(), $node->getArgs());
+    }
+
+    private function resolveMethodName(Node\Identifier|Node\Expr $name, Scope $scope): ?string
+    {
+        if ($name instanceof Node\Identifier) {
+            return $name->toString();
+        }
+
+        $constantStrings = $scope->getType($name)->getConstantStrings();
+        if (count($constantStrings) !== 1) {
+            return null;
+        }
+
+        return $constantStrings[0]->getValue();
+    }
+
+    /**
+     * @param list<\PHPStan\Reflection\ParametersAcceptor> $variants
+     * @param list<Node\Arg> $args
+     * @return list<Node\Expr>
+     */
+    private function resolveParametersAcceptorArguments(array $variants, array $args): array
+    {
         $targets = [];
-        foreach ($function->getVariants() as $variant) {
+        foreach ($variants as $variant) {
             $parameters = $variant->getParameters();
             $parameterCount = count($parameters);
             $variadicParameter = $variant->isVariadic() && $parameterCount > 0
                 ? $parameters[$parameterCount - 1]
                 : null;
 
-            foreach ($node->getArgs() as $index => $arg) {
+            foreach ($args as $index => $arg) {
                 // Spread arguments have an unknown mapping onto parameters.
                 if ($arg->unpack) {
                     continue;

--- a/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
+++ b/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
@@ -118,6 +118,31 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
         array &$errors,
         MutationTargetResolver $mutationTargetResolver,
     ): void {
+        if ($scope instanceof \PHPStan\Analyser\MutatingScope) {
+            foreach ($function->getParams() as $param) {
+                if (
+                    $param->var instanceof Node\Expr\Variable
+                    && is_string($param->var->name)
+                ) {
+                    $paramType = null;
+                    if ($param->type instanceof Node\Name) {
+                        $paramType = $scope->resolveTypeByName($param->type);
+                    } elseif ($param->type instanceof Node\NullableType && $param->type->type instanceof Node\Name) {
+                        $paramType = new \PHPStan\Type\NullableType($scope->resolveTypeByName($param->type->type));
+                    }
+
+                    if ($paramType !== null) {
+                        $scope = $scope->assignVariable(
+                            $param->var->name,
+                            $paramType,
+                            $paramType,
+                            \PHPStan\TrinaryLogic::createYes(),
+                        );
+                    }
+                }
+            }
+        }
+
         $traverser = new NodeTraverser();
         $visitor = new class($globalVars, $scope, $errors, $mutationTargetResolver) extends NodeVisitorAbstract {
             /** @var list<array<string|null>> */
@@ -131,9 +156,9 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
             private MutationTargetResolver $mutationTargetResolver;
 
             /**
-             * @param array<string|null> $globalVars
-             * @param array<\PHPStan\Rules\RuleError> $errors
-             */
+              * @param array<string|null> $globalVars
+              * @param array<\PHPStan\Rules\RuleError> $errors
+              */
             public function __construct(
                 array $globalVars,
                 Scope $scope,
@@ -156,6 +181,23 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
 
                     return null;
                 }
+
+                if ($node instanceof Node\Expr\Assign) {
+                    if (
+                        $this->scope instanceof \PHPStan\Analyser\MutatingScope
+                        && $node->var instanceof Node\Expr\Variable
+                        && is_string($node->var->name)
+                    ) {
+                        $assignedType = $this->scope->getType($node->expr);
+                        $this->scope = $this->scope->assignVariable(
+                            $node->var->name,
+                            $assignedType,
+                            $assignedType,
+                            \PHPStan\TrinaryLogic::createYes(),
+                        );
+                    }
+                }
+
                 foreach ($this->mutationTargetResolver->resolve($node, $this->scope) as $target) {
                     // `unset($db)` removes the local binding created by
                     // `global $db`; it does not remove the global variable.

--- a/tests/Config/StrictRulesetTest.php
+++ b/tests/Config/StrictRulesetTest.php
@@ -43,6 +43,7 @@ class StrictRulesetTest extends TestCase
             'issue-25-globals-by-reference.php',
             'issue-33-foreach-key-targets.php',
             'issue-34-strict-global-declared-mutation.php',
+            'issue-43-method-by-reference.php',
         ] as $fixture) {
             yield $fixture => [$fixture];
         }

--- a/tests/Rules/Data/issue-43-method-by-reference.php
+++ b/tests/Rules/Data/issue-43-method-by-reference.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AccessingGlobals\Tests\Rules\Data;
+
+final class StateService
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function update(array &$data): void
+    {
+        $data['modified'] = true;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function staticUpdate(array &$data): void
+    {
+        $data['modified'] = true;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function readOnly(array $data): void
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function staticReadOnly(array $data): void
+    {
+    }
+}
+
+function mutateViaInstanceMethod(StateService $service): void
+{
+    $service->update($_SESSION['items']);
+    $service->update($GLOBALS['config']);
+    $service?->update($_SESSION['items']);
+    $service->update(data: $_SESSION['items']);
+
+    // By-value calls must not be reported as mutations
+    $service->readOnly($_SESSION['items']);
+    $service->readOnly($GLOBALS['config']);
+}
+
+function mutateViaStaticMethod(): void
+{
+    StateService::staticUpdate($_SESSION['items']);
+    StateService::staticUpdate($GLOBALS['config']);
+    StateService::staticUpdate(data: $_SESSION['items']);
+
+    // By-value calls must not be reported as mutations
+    StateService::staticReadOnly($_SESSION['items']);
+    StateService::staticReadOnly($GLOBALS['config']);
+}
+
+function mutateGlobalKeywordViaMethod(StateService $service): void
+{
+    global $appData;
+    $service->update($appData);
+    StateService::staticUpdate($appData);
+
+    // By-value call must not be reported
+    $service->readOnly($appData);
+}

--- a/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
+++ b/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
@@ -323,4 +323,33 @@ class NeverModifyGloballyDeclaredVariablesRuleTest extends RuleTestCase
             ),
         );
     }
+
+    public function testIssue43MethodByReferenceGlobalKeyword(): void
+    {
+        require_once __DIR__ . "/Data/issue-43-method-by-reference.php";
+        $fixture = __DIR__ . "/Data/issue-43-method-by-reference.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying variable $appData that was declared with the "global" keyword. Use dependency injection instead.',
+                    66,
+                ],
+                [
+                    'Code is modifying variable $appData that was declared with the "global" keyword. Use dependency injection instead.',
+                    67,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 2, 'modify.global'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }
+

--- a/tests/Rules/NeverModifyGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifyGlobalsRuleTest.php
@@ -254,4 +254,33 @@ class NeverModifyGlobalsRuleTest extends RuleTestCase
             ),
         );
     }
+
+    public function testIssue43MethodByReferenceMutations(): void
+    {
+        require_once __DIR__ . "/Data/issue-43-method-by-reference.php";
+        $fixture = __DIR__ . "/Data/issue-43-method-by-reference.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying global variable through $GLOBALS[\'config\']. Use dependency injection instead.',
+                    43,
+                ],
+                [
+                    'Code is modifying global variable through $GLOBALS[\'config\']. Use dependency injection instead.',
+                    55,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 2, 'modify.global'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }
+

--- a/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsInNestedScopeRuleTest.php
@@ -365,4 +365,53 @@ class NeverModifySuperGlobalsInNestedScopeRuleTest extends RuleTestCase
             ),
         );
     }
+
+    public function testIssue43MethodByReferenceMutationsOnlyInNestedScope(): void
+    {
+        require_once __DIR__ . "/Data/issue-43-method-by-reference.php";
+        $fixture = __DIR__ . "/Data/issue-43-method-by-reference.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_SESSION in a nested scope. Return the new value instead.',
+                    42,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS in a nested scope. Return the new value instead.',
+                    43,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION in a nested scope. Return the new value instead.',
+                    44,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION in a nested scope. Return the new value instead.',
+                    45,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION in a nested scope. Return the new value instead.',
+                    54,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS in a nested scope. Return the new value instead.',
+                    55,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION in a nested scope. Return the new value instead.',
+                    56,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 7, 'modify.superglobal.nested'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }
+

--- a/tests/Rules/NeverModifySuperGlobalsRuleTest.php
+++ b/tests/Rules/NeverModifySuperGlobalsRuleTest.php
@@ -448,4 +448,54 @@ class NeverModifySuperGlobalsRuleTest extends RuleTestCase
             ),
         );
     }
+
+    public function testIssue43MethodByReferenceMutations(): void
+    {
+        require_once __DIR__ . "/Data/issue-43-method-by-reference.php";
+        $fixture = __DIR__ . "/Data/issue-43-method-by-reference.php";
+
+        $this->analyse(
+            [$fixture],
+            [
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    42,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    43,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    44,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    45,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    54,
+                ],
+                [
+                    'Code is modifying superglobal variable $GLOBALS. Return the new value instead.',
+                    55,
+                ],
+                [
+                    'Code is modifying superglobal variable $_SESSION. Return the new value instead.',
+                    56,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            array_fill(0, 7, 'modify.superglobal'),
+            array_map(
+                static fn(\PHPStan\Analyser\Error $error): ?string => $error->getIdentifier(),
+                $this->gatherAnalyserErrors([$fixture]),
+            ),
+        );
+    }
 }
+
+


### PR DESCRIPTION
## Summary

- Inspect `MethodCall` and `StaticCall` nodes in `MutationTargetResolver`, resolving by-reference parameters using PHPStan method reflection and argument matching.
- Enrich scope in `NeverModifyGloballyDeclaredVariablesRule` with function parameter types and local assignments so method calls on parameter variables and local variables can be resolved.
- Add regression coverage for instance method calls, static method calls, nullsafe method calls, named arguments, and by-value non-mutating calls across all `NeverModify*` rules.

## Root cause

`MutationTargetResolver` only inspected `FuncCall` nodes and fell back to rejecting all nodes not matching assignment or inc/dec expressions. Consequently, instance method calls (`$service->update($_SESSION['items'])`) and static method calls (`StateService::staticUpdate($_SESSION['items'])`) accepting by-reference arguments bypassed all `NeverModify*` rules.

## Validation

- `vendor/bin/phpunit` — 83 tests, 175 assertions pass
- Docker CI environments — both PHP 8.3 and 8.4 containers pass 83 tests
- Documented manual verification checks — expected exit code 1 with 36 / 28 / 13 violations

Closes #43