### PR TITLE
Fix short-name constant() lookups in namespaced classes (#44)

### DIFF
--- a/src/Rules/ForbidUsingClassConstantsRule.php
+++ b/src/Rules/ForbidUsingClassConstantsRule.php
@@ -153,10 +153,7 @@ class ForbidUsingClassConstantsRule implements Rule
         if ($classReflection !== null) {
             $currentClassName = $classReflection->getName();
 
-            if (
-                $normalizedClassName === $currentClassName
-                || str_ends_with($currentClassName, '\\' . $normalizedClassName)
-            ) {
+            if (strtolower($normalizedClassName) === strtolower($currentClassName)) {
                 return [];
             }
         }

--- a/tests/Rules/Data/issue-35-constant-class-lookup.php
+++ b/tests/Rules/Data/issue-35-constant-class-lookup.php
@@ -23,7 +23,7 @@ class Client extends BaseClass
         // OK: Accessing own constant via constant('self::...')
         $a = constant('self::OWN_TIMEOUT');
 
-        // OK: Accessing own constant via constant('Client::...')
+        // BAD: Accessing external class constant inside method (short name does not resolve to namespaced class)
         $b = constant('Client::OWN_TIMEOUT');
 
         // OK: Accessing own constant via fully-qualified name

--- a/tests/Rules/Data/issue-44-constant-class-lookup-namespaced.php
+++ b/tests/Rules/Data/issue-44-constant-class-lookup-namespaced.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    class Config
+    {
+        public const TIMEOUT = 60;
+
+        public function getOwnTimeout(): int
+        {
+            // OK: Accessing own constant in global namespace via constant('Config::...')
+            return constant('Config::TIMEOUT');
+        }
+    }
+}
+
+namespace App\Services {
+    class Config
+    {
+        public const LOCAL_TIMEOUT = 10;
+
+        public function getExternalTimeout(): int
+        {
+            // BAD: Accessing external global class constant Config::TIMEOUT from namespaced class
+            return constant('Config::TIMEOUT');
+        }
+
+        public function getOwnTimeouts(): int
+        {
+            // OK: Accessing own constant via fully-qualified class name
+            $a = constant('App\Services\Config::LOCAL_TIMEOUT');
+
+            // OK: Accessing own constant via fully-qualified class name with leading backslash
+            $b = constant('\App\Services\Config::LOCAL_TIMEOUT');
+
+            // OK: Accessing own constant via self keyword
+            $c = constant('self::LOCAL_TIMEOUT');
+
+            // OK: Accessing own constant via static keyword
+            $d = constant('static::LOCAL_TIMEOUT');
+
+            return $a + $b + $c + $d;
+        }
+    }
+}

--- a/tests/Rules/ForbidUsingClassConstantsRuleTest.php
+++ b/tests/Rules/ForbidUsingClassConstantsRuleTest.php
@@ -62,6 +62,10 @@ class ForbidUsingClassConstantsRuleTest extends RuleTestCase
             [__DIR__ . "/Data/issue-35-constant-class-lookup.php"],
             [
                 [
+                    "Code is accessing constant Client::OWN_TIMEOUT. This creates a hidden dependency; pass the value as an argument instead.",
+                    27,
+                ],
+                [
                     "Code is accessing constant Config::TIMEOUT. This creates a hidden dependency; pass the value as an argument instead.",
                     39,
                 ],
@@ -76,6 +80,19 @@ class ForbidUsingClassConstantsRuleTest extends RuleTestCase
                 [
                     "Code is accessing constant AccessingGlobals\Tests\Rules\Data\Issue35\Config::TIMEOUT. This creates a hidden dependency; pass the value as an argument instead.",
                     54,
+                ],
+            ],
+        );
+    }
+
+    public function testIssue44ClassConstantViaConstantInNamespace(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-44-constant-class-lookup-namespaced.php"],
+            [
+                [
+                    "Code is accessing constant Config::TIMEOUT. This creates a hidden dependency; pass the value as an argument instead.",
+                    26,
                 ],
             ],
         );


### PR DESCRIPTION
## Summary

- Remove `str_ends_with()` suffix exemption in `ForbidUsingClassConstantsRule::processConstantFunctionCall()`, requiring the normalized class name in `constant()` to match the enclosing class name exactly.
- Add test coverage for namespaced class constant lookups, verifying that unqualified class names accessing root constants are flagged under `constant.class`.
- Verify that lookups in the global root namespace, fully-qualified class names, and `self`/`static`/`parent` keywords continue to be allowed.

## Root cause

`ForbidUsingClassConstantsRule::processConstantFunctionCall()` exempted constant lookups when `str_ends_with($currentClassName, '\\' . $normalizedClassName)` evaluated to true. In PHP, `constant()` is evaluated exclusively in the root namespace at runtime and does not resolve relative to the enclosing class's namespace. Consequently, `constant('Class::CONST')` inside a namespaced class accesses `\Class::CONST` in the global namespace, but was erroneously treated as accessing the enclosing class's own constant and suppressed.

## Validation

- `vendor/bin/phpunit` — 84 tests, 176 assertions pass
- Documented manual verification checks — expected exit code 1 with 36 / 28 / 13 violations across basic, strict, and opinionated rulesets

Closes #44