### PR TITLE
Fix first-class callables bypassing ForbidImpureGlobalFunctionsRule (#45)

### DIFF
--- a/src/Rules/ForbidImpureGlobalFunctionsRule.php
+++ b/src/Rules/ForbidImpureGlobalFunctionsRule.php
@@ -8,12 +8,13 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
+use PHPStan\Node\FunctionCallableNode;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
- * @implements Rule<FuncCall>
+ * @implements Rule<Node\Expr>
  */
 class ForbidImpureGlobalFunctionsRule implements Rule
 {
@@ -78,11 +79,11 @@ class ForbidImpureGlobalFunctionsRule implements Rule
 
     public function getNodeType(): string
     {
-        return FuncCall::class;
+        return Node\Expr::class;
     }
 
     /**
-     * @param FuncCall $node
+     * @param Node\Expr $node
      */
     public function processNode(Node $node, Scope $scope): array
     {
@@ -93,13 +94,21 @@ class ForbidImpureGlobalFunctionsRule implements Rule
             return [];
         }
 
-        if (!$node->name instanceof Name) {
+        if ($node instanceof FunctionCallableNode) {
+            $name = $node->getName();
+        } elseif ($node instanceof FuncCall) {
+            $name = $node->name;
+        } else {
+            return [];
+        }
+
+        if (!$name instanceof Name) {
             // This handles dynamic function calls like `$functionName()`.
             // These are a separate problem and not the focus of this rule.
             return [];
         }
 
-        $resolvedFunctionName = $this->reflectionProvider->resolveFunctionName($node->name, $scope);
+        $resolvedFunctionName = $this->reflectionProvider->resolveFunctionName($name, $scope);
 
         if ($resolvedFunctionName === null) {
             return [];
@@ -112,7 +121,7 @@ class ForbidImpureGlobalFunctionsRule implements Rule
                 RuleErrorBuilder::message(
                     sprintf(
                         'Code is calling the impure function "%s()". This creates a hidden dependency on external state; pass the result as an argument instead.',
-                        $node->name->toString()
+                        $name->toString()
                     )
                 )
                     ->identifier('function.impure')

--- a/tests/Rules/Data/issue-45-first-class-callables.php
+++ b/tests/Rules/Data/issue-45-first-class-callables.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AccessingGlobals\Tests\Rules\Data\Issue45;
+
+function fetchAll(array $urls): array
+{
+    return array_map(file_get_contents(...), $urls);
+}
+
+function getRandomNumber(): int
+{
+    $generator = rand(...);
+
+    return $generator(1, 100);
+}
+
+function getSystemTime(): int
+{
+    return (time(...))();
+}
+
+function getEnvironmentVar(string $name): ?string
+{
+    $env = getenv(...);
+
+    return $env($name) ?: null;
+}
+
+function getLength(string $s): int
+{
+    $strlen = strlen(...);
+
+    return $strlen($s);
+}

--- a/tests/Rules/ForbidImpureGlobalFunctionsRuleTest.php
+++ b/tests/Rules/ForbidImpureGlobalFunctionsRuleTest.php
@@ -72,6 +72,31 @@ class ForbidImpureGlobalFunctionsRuleTest extends RuleTestCase
         );
     }
 
+    public function testIssue45FirstClassCallables(): void
+    {
+        $this->analyse(
+            [__DIR__ . "/Data/issue-45-first-class-callables.php"],
+            [
+                [
+                    'Code is calling the impure function "file_get_contents()". This creates a hidden dependency on external state; pass the result as an argument instead.',
+                    9,
+                ],
+                [
+                    'Code is calling the impure function "rand()". This creates a hidden dependency on external state; pass the result as an argument instead.',
+                    14,
+                ],
+                [
+                    'Code is calling the impure function "time()". This creates a hidden dependency on external state; pass the result as an argument instead.',
+                    21,
+                ],
+                [
+                    'Code is calling the impure function "getenv()". This creates a hidden dependency on external state; pass the result as an argument instead.',
+                    26,
+                ],
+            ],
+        );
+    }
+
     public function testIssue21NamespacedFunctionResolution(): void
     {
         // RuleTestCase analyzes fixtures in isolation, so load the declaration


### PR DESCRIPTION
## Summary

- Register `ForbidImpureGlobalFunctionsRule` for `Node\Expr` so it receives both ordinary `FuncCall` nodes and PHPStan's `FunctionCallableNode` virtual nodes.
- Resolve first-class callable names (`time(...)`, `rand(...)`, `getenv(...)`, `file_get_contents(...)`) the same way as ordinary calls, reporting `function.impure`.
- Add regression coverage for first-class callables, including a pure `strlen(...)` negative case.

## Root cause

`ForbidImpureGlobalFunctionsRule` implemented `Rule<FuncCall>` and returned `FuncCall::class` from `getNodeType()`. In PHP 8.1+, first-class callable syntax is rewritten by `PHPStan\Analyser\NodeScopeResolver` into `PHPStan\Node\FunctionCallableNode`. Because that node is not a `FuncCall`, PHPStan never invoked the rule, so `array_map(file_get_contents(...), $urls)` and `(time(...))()` produced no errors.

## Validation

- `vendor/bin/phpunit` — 85 tests, 177 assertions pass
- `vendor/bin/phpstan analyze -c config/rules-opinionated.neon tests/Rules/Data/issue-45-first-class-callables.php --level=0 --no-progress --error-format=raw` — 4 `function.impure` errors, exit code 1
- Documented manual verification checks — expected exit code 1 with 36 / 28 / 13 violations across basic, strict, and opinionated rulesets

Closes #45