### PR TITLE
fix: don't flag enum cases as forbidden class constants in ForbidUsingClassConstantsRule

### DIFF
--- a/src/Rules/ForbidUsingClassConstantsRule.php
+++ b/src/Rules/ForbidUsingClassConstantsRule.php
@@ -96,6 +96,13 @@ class ForbidUsingClassConstantsRule implements Rule
         // external class. This creates a hidden, compile-time dependency.
         $constantName = $node->name->toString();
 
+        // Enum cases are algebraic data type variants, not configuration constants.
+        // Referencing a case like `Priority::High` is idiomatic PHP 8.1+ and is not
+        // a hidden compile-time dependency on a constant value.
+        if ($this->isEnumCase($resolvedFetchedClassName, $constantName)) {
+            return [];
+        }
+
         return [
             $this->buildClassConstantError($resolvedFetchedClassName, $constantName),
         ];
@@ -158,9 +165,22 @@ class ForbidUsingClassConstantsRule implements Rule
             }
         }
 
+        if ($this->isEnumCase($normalizedClassName, $constantName)) {
+            return [];
+        }
+
         return [
             $this->buildClassConstantError($normalizedClassName, $constantName),
         ];
+    }
+
+    private function isEnumCase(string $className, string $constantName): bool
+    {
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return false;
+        }
+
+        return $this->reflectionProvider->getClass($className)->hasEnumCase($constantName);
     }
 
     private function buildClassConstantError(string $className, string $constantName): IdentifierRuleError

--- a/tests/Rules/Data/Issue46/EnumCaseViaConstant.php
+++ b/tests/Rules/Data/Issue46/EnumCaseViaConstant.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AccessingGlobals\Tests\Rules\Data\Issue46;
+
+final class EnumCaseViaConstant
+{
+    public function describe(Priority $priority): string
+    {
+        // OK: Enum case via constant() is not a forbidden constant lookup
+        if (constant(Priority::class . '::High') === $priority) {
+            return 'Urgent priority';
+        }
+
+        // BAD: Real class constant via constant() is still forbidden
+        return constant('AccessingGlobals\Tests\Rules\Data\Issue46\Priority::DEFAULT_PRIORITY');
+    }
+}

--- a/tests/Rules/Data/Issue46/Priority.php
+++ b/tests/Rules/Data/Issue46/Priority.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AccessingGlobals\Tests\Rules\Data\Issue46;
+
+enum Priority: string
+{
+    case Low = 'low';
+    case High = 'high';
+
+    public const DEFAULT_PRIORITY = 'low';
+}

--- a/tests/Rules/Data/Issue46/Task.php
+++ b/tests/Rules/Data/Issue46/Task.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AccessingGlobals\Tests\Rules\Data\Issue46;
+
+final class Task
+{
+    public function isUrgent(Priority $priority): bool
+    {
+        return $priority === Priority::High;
+    }
+
+    public function describe(Priority $priority): string
+    {
+        return match ($priority) {
+            Priority::High => 'Urgent priority',
+            Priority::Low => 'Normal priority',
+        };
+    }
+
+    public function getDefaultPriority(): string
+    {
+        return Priority::DEFAULT_PRIORITY;
+    }
+}

--- a/tests/Rules/ForbidUsingClassConstantsRuleIssue46Test.php
+++ b/tests/Rules/ForbidUsingClassConstantsRuleIssue46Test.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AccessingGlobals\Tests\Rules;
+
+use AccessingGlobals\Rules\ForbidUsingClassConstantsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbidUsingClassConstantsRule>
+ */
+class ForbidUsingClassConstantsRuleIssue46Test extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ForbidUsingClassConstantsRule(self::createReflectionProvider());
+    }
+
+    public function testEnumCasesAreNotForbiddenClassConstants(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . "/Data/Issue46/Priority.php",
+                __DIR__ . "/Data/Issue46/Task.php",
+                __DIR__ . "/Data/Issue46/EnumCaseViaConstant.php",
+            ],
+            [
+                [
+                    "Code is accessing constant AccessingGlobals\Tests\Rules\Data\Issue46\Priority::DEFAULT_PRIORITY. This creates a hidden dependency; pass the value as an argument instead.",
+                    24,
+                ],
+                [
+                    "Code is accessing constant AccessingGlobals\Tests\Rules\Data\Issue46\Priority::DEFAULT_PRIORITY. This creates a hidden dependency; pass the value as an argument instead.",
+                    17,
+                ],
+            ],
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `ForbidUsingClassConstantsRule` flagged enum case references (`Priority::High`, `Priority::Low`) in `match` arms, identity comparisons, and `constant('Enum::Case')` lookups as forbidden class constants (`constant.class`).
- Enum cases are algebraic data type variants of the enum, not configuration constants, so the "pass the value as an argument instead" advice was nonsensical and made idiomatic PHP 8.1+ enums unusable under `config/rules-opinionated.neon`.
- The rule now consults `ReflectionProvider` and returns early when the fetched member is an enum case (`ClassReflection::hasEnumCase`), in both `processClassConstFetch` and `processConstantFunctionCall`. Real class constants declared on the enum (e.g. `Priority::DEFAULT_PRIORITY`) are still reported.

## Root cause

PHP-Parser parses both class constant fetches and enum case accesses into `ClassConstFetch`, and the rule assumed every fetch on another class was a forbidden configuration constant. Only PHPStan's reflection API can distinguish the two, and the rule never asked it.

## Testing

- New regression test `ForbidUsingClassConstantsRuleIssue46Test` covers enum cases in `match`, `===`, `constant('...Enum::Case')` (all clean) and `Priority::DEFAULT_PRIORITY` via both syntaxes (still reported).
- Full suite green: 86 tests, 178 assertions.
- Manual CLI verification with the issue's reproducer reports only `Priority::DEFAULT_PRIORITY` (was 4 errors, now 1).

Fixes #46