### PR TITLE
fix: detect global object mutations in arrow functions and by-value closures (#47)

### DIFF
--- a/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
+++ b/src/Rules/NeverModifyGloballyDeclaredVariablesRule.php
@@ -145,7 +145,15 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
 
         $traverser = new NodeTraverser();
         $visitor = new class($globalVars, $scope, $errors, $mutationTargetResolver) extends NodeVisitorAbstract {
-            /** @var list<array<string|null>> */
+            /**
+             * One frame per function-like scope. `aliased` bindings still refer
+             * to the global variable itself, so any write to them mutates it.
+             * `byValue` bindings are copies of the binding (an arrow function's
+             * implicit capture, or a by-value `use`); only writes reached
+             * through an object handle escape the copy.
+             *
+             * @var list<array{aliased: array<string|null>, byValue: array<string|null>}>
+             */
             private array $bindingStack;
 
             private Scope $scope;
@@ -165,7 +173,7 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
                 array &$errors,
                 MutationTargetResolver $mutationTargetResolver,
             ) {
-                $this->bindingStack = [$globalVars];
+                $this->bindingStack = [['aliased' => $globalVars, 'byValue' => []]];
                 $this->scope = $scope;
                 $this->errors = &$errors;
                 $this->mutationTargetResolver = $mutationTargetResolver;
@@ -175,7 +183,7 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
             {
                 if ($node instanceof Node\FunctionLike) {
                     $this->bindingStack[] = $this->bindingsForNested($node);
-                    if ($this->currentGlobals() === []) {
+                    if ($this->currentBindings() === ['aliased' => [], 'byValue' => []]) {
                         return NodeVisitor::DONT_TRAVERSE_CHILDREN;
                     }
 
@@ -209,10 +217,16 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
                     }
 
                     $globalTarget = $target;
+                    // A write reached through a property fetch goes through an
+                    // object handle, which a by-value capture shares with the
+                    // global; array dimensions are copied, so they do not.
+                    $throughObjectHandle = false;
                     while (
                         $globalTarget instanceof Node\Expr\ArrayDimFetch
                         || $globalTarget instanceof Node\Expr\PropertyFetch
                     ) {
+                        $throughObjectHandle = $throughObjectHandle
+                            || $globalTarget instanceof Node\Expr\PropertyFetch;
                         $globalTarget = $globalTarget->var;
                     }
 
@@ -220,13 +234,18 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
                         continue;
                     }
 
+                    $bindings = $this->currentBindings();
+                    $candidates = $throughObjectHandle
+                        ? array_merge($bindings['aliased'], $bindings['byValue'])
+                        : $bindings['aliased'];
+
                     $targetName = GlobalVariableNameResolver::resolve($globalTarget, $this->scope);
                     // A null binding represents an unresolved dynamic name. Match
                     // only another unresolved target and keep its diagnostic generic.
                     $matchesKnownBinding = $targetName !== null
-                        && in_array($targetName, $this->currentGlobals(), true);
+                        && in_array($targetName, $candidates, true);
                     $matchesDynamicBinding = $targetName === null
-                        && in_array(null, $this->currentGlobals(), true);
+                        && in_array(null, $candidates, true);
 
                     if ($matchesKnownBinding || $matchesDynamicBinding) {
                         $message = $targetName === null
@@ -257,41 +276,60 @@ class NeverModifyGloballyDeclaredVariablesRule implements Rule
             }
 
             /**
-             * @return array<string|null>
+             * @return array{aliased: array<string|null>, byValue: array<string|null>}
              */
-            private function currentGlobals(): array
+            private function currentBindings(): array
             {
-                return $this->bindingStack[array_key_last($this->bindingStack)] ?? [];
+                return $this->bindingStack[array_key_last($this->bindingStack)]
+                    ?? ['aliased' => [], 'byValue' => []];
             }
 
             /**
-             * @return array<string|null>
+             * @return array{aliased: array<string|null>, byValue: array<string|null>}
              */
             private function bindingsForNested(Node\FunctionLike $node): array
             {
-                $inherited = [];
-                if ($node instanceof Node\Expr\Closure) {
+                $enclosing = $this->currentBindings();
+                $aliased = [];
+                $byValue = [];
+
+                if ($node instanceof Node\Expr\ArrowFunction) {
+                    // An arrow function implicitly captures every enclosing
+                    // variable it uses, always by value.
+                    $byValue = array_merge($enclosing['aliased'], $enclosing['byValue']);
+                } elseif ($node instanceof Node\Expr\Closure) {
                     foreach ($node->uses as $use) {
                         $name = $use->var->name;
-                        if (
-                            $use->byRef
-                            && is_string($name)
-                            && in_array($name, $this->currentGlobals(), true)
+                        if (!is_string($name)) {
+                            continue;
+                        }
+
+                        if ($use->byRef && in_array($name, $enclosing['aliased'], true)) {
+                            // A by-ref capture of the global binding still
+                            // aliases the global variable.
+                            $aliased[] = $name;
+                        } elseif (
+                            in_array($name, $enclosing['aliased'], true)
+                            || in_array($name, $enclosing['byValue'], true)
                         ) {
-                            $inherited[] = $name;
+                            // Everything else is a copy of the binding: a
+                            // by-value capture, or a by-ref capture of a copy.
+                            $byValue[] = $name;
                         }
                     }
                 }
+
                 foreach ($node->getParams() as $param) {
                     if (
                         $param->var instanceof Node\Expr\Variable
                         && is_string($param->var->name)
                     ) {
-                        $inherited = array_values(array_diff($inherited, [$param->var->name]));
+                        $aliased = array_values(array_diff($aliased, [$param->var->name]));
+                        $byValue = array_values(array_diff($byValue, [$param->var->name]));
                     }
                 }
 
-                return $inherited;
+                return ['aliased' => $aliased, 'byValue' => $byValue];
             }
         };
 

--- a/tests/Rules/Data/issue-47-nested-scope-property-mutation.php
+++ b/tests/Rules/Data/issue-47-nested-scope-property-mutation.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AccessingGlobals\Tests\Rules\Data;
+
+function issue47ArrowFunctionPropertyMutation(): void
+{
+    global $state;
+
+    // Objects are captured as handles, so an arrow function mutates the
+    // globally declared object in place.
+    $increment = fn(): int => $state->counter++;
+    $increment();
+}
+
+function issue47ByValueClosurePropertyMutation(): void
+{
+    global $state;
+
+    $reset = function () use ($state): void {
+        $state->status = 'ready';
+        $state->items['seen'] = true;
+        unset($state->items['seen']);
+    };
+    $reset();
+}
+
+function issue47ByValueClosureLocalWritesAreNotMutations(): void
+{
+    global $db;
+
+    // A by-value capture copies the binding itself, so writing to the copy
+    // or to its array dimensions never reaches the global.
+    $local = function () use ($db): void {
+        $db = 'local only';
+        $db['key'] = 'local only';
+    };
+    $local();
+}
+
+function issue47ShadowingParametersAreNotGlobals(): void
+{
+    global $state;
+
+    $shadowed = fn(\stdClass $state): int => $state->counter++;
+    $shadowed(new \stdClass());
+}
+
+function issue47NestedArrowFunctionInsideClosure(): void
+{
+    global $state;
+
+    $outer = function () use ($state): callable {
+        return fn(): string => $state->status = 'nested';
+    };
+    $outer();
+}

--- a/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
+++ b/tests/Rules/NeverModifyGloballyDeclaredVariablesRuleTest.php
@@ -351,5 +351,25 @@ class NeverModifyGloballyDeclaredVariablesRuleTest extends RuleTestCase
             ),
         );
     }
-}
 
+    public function testIssue47NestedScopePropertyMutations(): void
+    {
+        // https://github.com/jonbaldie/phpstan-extension-accessing-globals/issues/47
+        // Arrow functions and by-value `use` captures still share the object
+        // handle, so property writes inside them mutate the global object.
+        $fixture = __DIR__ . "/Data/issue-47-nested-scope-property-mutation.php";
+
+        $message = 'Code is modifying variable $state that was declared with the "global" keyword. Use dependency injection instead.';
+
+        $this->analyse(
+            [$fixture],
+            [
+                [$message, 13],
+                [$message, 22],
+                [$message, 23],
+                [$message, 24],
+                [$message, 55],
+            ],
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`NeverModifyGloballyDeclaredVariablesRule` missed object-property mutations of a `global`-declared variable when they happened inside an arrow function (`fn() => $state->counter++`) or inside a closure capturing the object by value (`function () use ($state) { $state->status = 'ready'; }`). Only `access.global` was reported; zero `modify.global` diagnostics were emitted.

## Root cause

Confirmed by probe: a by-ref capture (`use (&$state)`) was reported, while the arrow function and by-value capture were not.

`bindingsForNested()` returned an empty binding list for those scopes — an `ArrowFunction` is not a `Closure`, and by-value `use` captures were dropped by the `$use->byRef` gate added in #4 — so `enterNode()` aborted with `DONT_TRAVERSE_CHILDREN` and never visited the nested body.

## Fix

Each scope frame now tracks two binding kinds instead of one:

- **`aliased`** — still refers to the global variable itself (the function body's own `global` declarations, and by-ref `use` of one). Any write is a mutation.
- **`byValue`** — a copy of the binding (an arrow function's implicit capture, a by-value `use`, or a by-ref capture of a copy). Only writes reached *through an object handle* escape the copy, so a property fetch anywhere in the target chain is reported and a write to the copy itself is not.

This preserves #4's behaviour: inside a by-value closure, `$db = 'local only'` and `$db['key'] = 'local only'` stay unreported, since scalars and array dimensions are copied.

## Verification

- New fixture `tests/Rules/Data/issue-47-nested-scope-property-mutation.php` covers the arrow function, by-value closure property/array-property/unset writes, local-only writes that must stay silent, parameter shadowing, and an arrow function nested inside a closure.
- The regression test was watched failing (zero errors) before the fix and passing after.
- Full suite: 87 tests, 179 assertions, green.
- The issue's original reproducer now emits `modify.global` on both expected lines.
- All documented manual-verification error counts are unchanged (3 / 5 / 9 / 19 basic, 9 / 19 strict).

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)